### PR TITLE
Fix freeze on long path find executions

### DIFF
--- a/vnavmesh/NavVolume/VoxelPathfind.cs
+++ b/vnavmesh/NavVolume/VoxelPathfind.cs
@@ -97,7 +97,7 @@ public class VoxelPathfind
         return true;
     }
 
-    public void Execute(int maxSteps = int.MaxValue)
+    public void Execute(int maxSteps = 20000)
     {
         while (maxSteps-- > 0 && ExecuteStep())
             ;

--- a/vnavmesh/NavmeshQuery.cs
+++ b/vnavmesh/NavmeshQuery.cs
@@ -73,7 +73,7 @@ public class NavmeshQuery
             Service.Log.Error($"Failed to find a path from {from} ({startVoxel:X}) to {to} ({endVoxel:X}): failed to find empty voxel");
             return new();
         }
-
+        
         var voxelPath = VolumeQuery.FindPath(startVoxel, endVoxel, from, to, useRaycast, false); // TODO: do we need intermediate points for string-pulling algo?
         if (voxelPath.Count == 0)
         {


### PR DESCRIPTION
Reduces max steps from int max value to 20,000, stopping the while loop locking up the thread for a really long time if the step can continue to execute for some reason.