### PR TITLE
Current pathfind cancel

### DIFF
--- a/vnavmesh/IPCProvider.cs
+++ b/vnavmesh/IPCProvider.cs
@@ -18,6 +18,7 @@ namespace Navmesh
             RegisterFunc("Nav.Rebuild", () => navmeshManager.Reload(false));
             RegisterFunc("Nav.Pathfind", (Vector3 from, Vector3 to, bool fly) => navmeshManager.QueryPath(from, to, fly));
             RegisterFunc("Nav.PathfindCancelable", (Vector3 from, Vector3 to, bool fly, CancellationToken cancel) => navmeshManager.QueryPath(from, to, fly, cancel));
+            RegisterAction("Nav.PathfindCancelCurrent", () => navmeshManager.CancelCurrentPathfinding());
             RegisterFunc("Nav.PathfindInProgress", () => navmeshManager.PathfindInProgress);
             RegisterFunc("Nav.PathfindNumQueued", () => navmeshManager.NumQueuedPathfindRequests);
             RegisterFunc("Nav.IsAutoLoad", () => navmeshManager.AutoLoad);

--- a/vnavmesh/NavmeshManager.cs
+++ b/vnavmesh/NavmeshManager.cs
@@ -95,7 +95,7 @@ public class NavmeshManager : IDisposable
         // at this point, we're not loading a mesh
         if (_query != null)
         {
-            if (_currentPathfindTask != null && _currentPathfindTask.IsCompleted)
+            if (_currentPathfindTask != null && (_currentPathfindTask.IsCompleted || _currentPathfindTask.IsCanceled))
             {
                 _currentPathfindTask = null;
             }
@@ -149,6 +149,19 @@ public class NavmeshManager : IDisposable
         });
         _queuedPathfindTasks.Add(task);
         return task;
+    }
+
+    public void CancelCurrentPathfinding()
+    {
+        if (_queryCancelSource == null || _currentPathfindTask is null || _query == null)
+        {
+            Service.Log.Error($"Can't cancel query - navmesh is not loaded");
+            return;
+        }
+
+        _queryCancelSource.Cancel(); // this will cancel current pathfind task
+        _queryCancelSource = new(); // create new token source for future tasks
+
     }
 
     // if non-empty string is returned, active layout is ready


### PR DESCRIPTION
- Simpler IPC for cancelling the current pathfind task without concerning IPC users with cancellation tokens and tracking from/to points.