### PR TITLE
add command collider

### DIFF
--- a/vnavmesh/Debug/DebugGameCollision.cs
+++ b/vnavmesh/Debug/DebugGameCollision.cs
@@ -37,11 +37,12 @@ public unsafe class DebugGameCollision : IDisposable
 
     private delegate bool RaycastDelegate(SceneWrapper* self, RaycastHit* result, ulong layerMask, RaycastParams* param);
     private Hook<RaycastDelegate>? _raycastHook;
+    public bool IsCmdEnabledCollision { get; set; } = false;
 
-    public DebugGameCollision(DebugDrawer dd)
+    public DebugGameCollision(DebugDrawer dd, int bufferSize = 4096)
     {
         _dd = dd;
-        _meshDynamicData = new(dd.RenderContext, 1024 * 1024, 1024 * 1024, 128 * 1024, true);
+        _meshDynamicData = new(dd.RenderContext, 1024 * bufferSize, 1024 * bufferSize, 128 * bufferSize, true);
 
         foreach (var s in Framework.Instance()->BGCollisionModule->SceneManager->Scenes)
         {
@@ -215,7 +216,7 @@ public unsafe class DebugGameCollision : IDisposable
     private void DrawSceneColliders(Scene* s, int index)
     {
         using var n = _tree.Node($"Scene {index}: {s->NumColliders} colliders, {s->NumLoading} loading, streaming={SphereStr(s->StreamingSphere)}###scene_{index}");
-        if (n.SelectedOrHovered)
+        if (n.SelectedOrHovered || IsCmdEnabledCollision)
             foreach (var coll in s->Colliders)
                 if (FilterCollider(coll))
                     VisualizeCollider(coll, _materialId, _materialMask);
@@ -707,4 +708,3 @@ public unsafe class DebugGameCollision : IDisposable
         return _raycastHook!.Original(self, result, layerMask, param);
     }
 }
-

--- a/vnavmesh/MainWindow.cs
+++ b/vnavmesh/MainWindow.cs
@@ -54,4 +54,9 @@ public class MainWindow : Window, IDisposable
         }
         _dd.EndFrame();
     }
+
+    public void ToggleIsCmdEnabledCollision()
+    {
+        _debugGameColl.IsCmdEnabledCollision = !_debugGameColl.IsCmdEnabledCollision;
+    }
 }

--- a/vnavmesh/Plugin.cs
+++ b/vnavmesh/Plugin.cs
@@ -62,6 +62,7 @@ public sealed class Plugin : IDalamudPlugin
             /vnavmesh rebuild → rebuild current territory's navmesh from scratch
             /vnavmesh aligncamera → toggle aligning camera to movement direction
             /vnavmesh dtr → toggle dtr status
+            /vnavmesh collider → toggle collision debug visualization
             """,
             ShowInHelp = true,
         });
@@ -148,6 +149,9 @@ public sealed class Plugin : IDalamudPlugin
                 break;
             case "dtr":
                 _dtrProvider.ShowDtrBar ^= true;
+                break;
+            case "collider":
+                _wndMain.ToggleIsCmdEnabledCollision();
                 break;
         }
     }


### PR DESCRIPTION
hi,

this pr adds a command to toggle show/hide the game collision debug visualization.

a standalong drawer seems to require making a bunch instances so that I keep the changes to your existing code minimal and this cmd is only working when the mainwindow is shown.