### PR TITLE
Update API 10 - Update interfaces, version and checks sigs, and updated FFXIVClientStructs

### DIFF
--- a/vnavmesh/DTRProvider.cs
+++ b/vnavmesh/DTRProvider.cs
@@ -6,7 +6,7 @@ namespace Navmesh;
 public class DTRProvider : IDisposable
 {
     private NavmeshManager _manager;
-    private DtrBarEntry _dtrBarEntry;
+    private IDtrBarEntry _dtrBarEntry;
 
     public DTRProvider(NavmeshManager manager)
     {
@@ -16,7 +16,7 @@ public class DTRProvider : IDisposable
 
     public void Dispose()
     {
-        _dtrBarEntry.Dispose();
+        _dtrBarEntry.Remove();
     }
 
     public void Update()

--- a/vnavmesh/Plugin.cs
+++ b/vnavmesh/Plugin.cs
@@ -21,7 +21,7 @@ public sealed class Plugin : IDalamudPlugin
     private MainWindow _wndMain;
     private IPCProvider _ipcProvider;
 
-    public Plugin(DalamudPluginInterface dalamud)
+    public Plugin(IDalamudPluginInterface dalamud)
     {
         if (!dalamud.ConfigDirectory.Exists)
             dalamud.ConfigDirectory.Create();

--- a/vnavmesh/Service.cs
+++ b/vnavmesh/Service.cs
@@ -23,7 +23,7 @@ public class Service
     [PluginService] public static IAddonLifecycle AddonLifecycle { get; private set; } = null!;
     [PluginService] public static IFramework Framework { get; private set; } = null!;
     [PluginService] public static IDtrBar DtrBar { get; private set; } = null!;
-    [PluginService] public static DalamudPluginInterface PluginInterface { get; private set; } = null!;
+    [PluginService] public static IDalamudPluginInterface PluginInterface { get; private set; } = null!;
     [PluginService] public static IGameConfig GameConfig { get; private set; } = null!;
 
     public static Lumina.GameData LuminaGameData => DataManager.GameData;

--- a/vnavmesh/packages.lock.json
+++ b/vnavmesh/packages.lock.json
@@ -4,9 +4,9 @@
     "net8.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[2.1.12, )",
-        "resolved": "2.1.12",
-        "contentHash": "Sc0PVxvgg4NQjcI8n10/VfUQBAS4O+Fw2pZrAqBdRMbthYGeogzu5+xmIGCGmsEZ/ukMOBuAqiNiB5qA3MRalg=="
+        "requested": "[2.1.13, )",
+        "resolved": "2.1.13",
+        "contentHash": "rMN1omGe8536f4xLMvx9NwfvpAc9YFFfeXJ1t4P4PE6Gu8WCIoFliR1sh07hM+bfODmesk/dvMbji7vNI+B/pQ=="
       },
       "SharpDX.D3DCompiler": {
         "type": "Direct",

--- a/vnavmesh/vnavmesh.csproj
+++ b/vnavmesh/vnavmesh.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DalamudPackager" Version="2.1.12" />
+    <PackageReference Include="DalamudPackager" Version="2.1.13" />
     <PackageReference Include="SharpDX.D3DCompiler" Version="4.2.0" />
     <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" />
     <PackageReference Include="SharpDX.Mathematics" Version="4.2.0" />


### PR DESCRIPTION
All sigs seemed OK, only that one is called now two times in 7.0 [Signature("40 53 48 83 EC 70 44 0F 29 44 24 ?? 48 8B D9")] (but nothing seemed broken), however I still tested it and on new maps and old maps and different type of movements and it's seem to be working as expected.

Just it need latest  FFXIVClientStructs, rebuilded