### PR TITLE
stop hardlocking during volume pathfind

### DIFF
--- a/vnavmesh/NavVolume/VoxelSearch.cs
+++ b/vnavmesh/NavVolume/VoxelSearch.cs
@@ -52,8 +52,12 @@ public static class VoxelSearch
     {
         var ab = toPos - fromPos;
         var eps = 0.1f / ab.Length();
+        var iters = 0;
         while (fromVoxel != toVoxel)
         {
+            iters += 1;
+            if (iters > 10000)
+                throw new Exception("Too many iterations in EnumerateVoxelsInLine (> 10000)");
             var bounds = volume.VoxelBounds(fromVoxel, 0);
             // find closest intersection among three (out of six) neighbours
             // line-plane intersection: Q = A + AB*t, PQ*n=0 => (PA + tAB)*n = 0 => t = AP*n / AB*n


### PR DESCRIPTION
sometimes this loop is infinite, which makes the task unkillable and forces you to kill your game process from task manager or xllog if you want to restart