### PR TITLE
navmesh io and compression fix

### DIFF
--- a/vnavmesh/NavmeshManager.cs
+++ b/vnavmesh/NavmeshManager.cs
@@ -235,7 +235,7 @@ public class NavmeshManager : IDisposable
         // write results to cache
         {
             Service.Log.Debug($"Writing cache: {cache.FullName}");
-            using var stream = cache.OpenWrite();
+            using var stream = new FileStream(cache.FullName, FileMode.Create, FileAccess.Write);
             using var writer = new BinaryWriter(stream);
             builder.Navmesh.Serialize(writer);
         }


### PR DESCRIPTION
two fixes for navmesh files: 
1) files were not being truncated prior to writing (vnavmesh/NavmeshManager.cs)
2) brotli compression is now applied to navmesh cache files (vnavmesh/Navmesh.cs) (around 85% reduction in file size)