### PR TITLE
added antistuck and stale node removal for mesh paths

### DIFF
--- a/vnavmesh/AsyncMoveRequest.cs
+++ b/vnavmesh/AsyncMoveRequest.cs
@@ -39,7 +39,7 @@ public class AsyncMoveRequest : IDisposable
             Service.Log.Information($"Pathfinding complete");
             try
             {
-                _follow.Move(_pendingTask.Result, !_pendingFly);
+                _follow.Move(_pendingTask.Result, _pendingFly);
             }
             catch (Exception ex)
             {

--- a/vnavmesh/IPCProvider.cs
+++ b/vnavmesh/IPCProvider.cs
@@ -27,7 +27,7 @@ class IPCProvider : IDisposable
         RegisterFunc("Query.Mesh.NearestPoint", (Vector3 p, float halfExtentXZ, float halfExtentY) => navmeshManager.Query?.FindNearestPointOnMesh(p, halfExtentXZ, halfExtentY));
         RegisterFunc("Query.Mesh.PointOnFloor", (Vector3 p, bool allowUnlandable, float halfExtentXZ) => navmeshManager.Query?.FindPointOnFloor(p, halfExtentXZ));
 
-        RegisterAction("Path.MoveTo", (List<Vector3> waypoints, bool fly) => followPath.Move(waypoints, !fly));
+        RegisterAction("Path.MoveTo", (List<Vector3> waypoints, bool fly) => followPath.Move(waypoints, fly));
         RegisterAction("Path.Stop", followPath.Stop);
         RegisterFunc("Path.IsRunning", () => followPath.Waypoints.Count > 0);
         RegisterFunc("Path.NumWaypoints", () => followPath.Waypoints.Count);

--- a/vnavmesh/NavmeshQuery.cs
+++ b/vnavmesh/NavmeshQuery.cs
@@ -62,12 +62,14 @@ public class NavmeshQuery
                 Service.Log.Error($"Failed to find a path from {from} ({startRef:X}) to {to} ({endRef:X}): failed to find straight path ({success.Value:X})");
             var res = straightPath.Select(p => p.pos.RecastToSystem()).ToList();
             res.Add(endPos.RecastToSystem());
+            res.RemoveAt(0);
             return res;
         }
         else
         {
             var res = polysPath.Select(r => MeshQuery.GetAttachedNavMesh().GetPolyCenter(r).RecastToSystem()).ToList();
             res.Add(endPos.RecastToSystem());
+            res.RemoveAt(0);
             return res;
         }
     }
@@ -101,6 +103,7 @@ public class NavmeshQuery
         // TODO: string-pulling support
         var res = voxelPath.Select(r => r.p).ToList();
         res.Add(to);
+        res.RemoveAt(0);
         return res;
     }
 

--- a/vnavmesh/Plugin.cs
+++ b/vnavmesh/Plugin.cs
@@ -40,6 +40,7 @@ public sealed class Plugin : IDalamudPlugin
         _navmeshManager = new(new($"{dalamud.ConfigDirectory.FullName}/meshcache"));
         _followPath = new(_navmeshManager);
         _asyncMove = new(_navmeshManager, _followPath);
+        _followPath.SetAsyncMove(_asyncMove);
         _dtrProvider = new(_navmeshManager);
         _wndMain = new(_navmeshManager, _followPath, _asyncMove, _dtrProvider);
         _ipcProvider = new(_navmeshManager, _followPath, _asyncMove, _wndMain, _dtrProvider);


### PR DESCRIPTION
hello, please review the following additions:

1. Changed FollowPath's Move parameter so calls do not need to flip the bool to increase readability. Also simplified the Threshold check
2. For Mesh PathFindMoveTo, 3 checks have been added that will trigger a moveto command if the original path was not called with flying enabled. The moveto commands are limited to 1 per 500 ms.
  a.  Check 1: if Player is moving away from currentNode, send a MoveTo command to the goal (if not flying)
  b.  Check 2: if Player is stuck, send a MoveTo command to the goal (if not flying)
  c.   Check 3: if currentNode is stale, removes the node,. if the player is not flying, also calls MoveTo 