### PR TITLE
fix followpath for short dive path

### DIFF
--- a/vnavmesh/Movement/FollowPath.cs
+++ b/vnavmesh/Movement/FollowPath.cs
@@ -71,7 +71,7 @@ public class FollowPath : IDisposable
             OverrideAFK.ResetTimers();
             _movement.Enabled = MovementAllowed;
             _movement.DesiredPosition = Waypoints[0];
-            if (_movement.DesiredPosition.Y > player.Position.Y && !Service.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.InFlight] && !Service.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.Diving] && && !IgnoreDeltaY) //Only do this bit if on a flying path
+            if (_movement.DesiredPosition.Y > player.Position.Y && !Service.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.InFlight] && !Service.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.Diving] && !IgnoreDeltaY) //Only do this bit if on a flying path
             {
                 // walk->fly transition (TODO: reconsider?)
                 if (Service.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.Mounted])

--- a/vnavmesh/Movement/FollowPath.cs
+++ b/vnavmesh/Movement/FollowPath.cs
@@ -71,7 +71,7 @@ public class FollowPath : IDisposable
             OverrideAFK.ResetTimers();
             _movement.Enabled = MovementAllowed;
             _movement.DesiredPosition = Waypoints[0];
-            if (_movement.DesiredPosition.Y > player.Position.Y && !Service.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.InFlight] && !IgnoreDeltaY) //Only do this bit if on a flying path
+            if (_movement.DesiredPosition.Y > player.Position.Y && !Service.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.InFlight] && !Service.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.Diving] && && !IgnoreDeltaY) //Only do this bit if on a flying path
             {
                 // walk->fly transition (TODO: reconsider?)
                 if (Service.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.Mounted])


### PR DESCRIPTION
navmesh will wait for mount indefinitely when doing a flight path which is normally ok, but when diving Y-axis movement is possible without mounting - this will fix the bug with the visland coral path