### PR TITLE
Update FollowPath.cs to prevent executing jump while diving.

### DIFF
--- a/vnavmesh/Movement/FollowPath.cs
+++ b/vnavmesh/Movement/FollowPath.cs
@@ -109,6 +109,10 @@ public class FollowPath : IDisposable
 
     private unsafe void ExecuteJump()
     {
+        // Unable to jump while diving, prevents spamming error messages.
+        if (Service.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.Diving])
+	        return;
+        
         if (DateTime.Now >= _nextJump)
         {
             ActionManager.Instance()->UseAction(ActionType.GeneralAction, 2);


### PR DESCRIPTION
Occasionally when pathing while diving it'll get stuck attempting to jump, causing an error toast to appear.