### PR TITLE
Refactor navmesh cache handling to use configurable directory

### DIFF
--- a/vnavmesh/NavmeshManager.cs
+++ b/vnavmesh/NavmeshManager.cs
@@ -34,13 +34,24 @@ public sealed class NavmeshManager : IDisposable
 
     private DirectoryInfo _cacheDir;
 
-    public NavmeshManager(DirectoryInfo cacheDir)
+    public NavmeshManager()
     {
-        _cacheDir = cacheDir;
-        cacheDir.Create(); // ensure directory exists
+        _cacheDir = new DirectoryInfo(Service.Config.MeshDirectory);
+        _cacheDir.Create(); // ensure directory exists
+        Service.Config.Modified += OnConfigModified;
 
         // prepare a task with correct task scheduler that other tasks can be chained off
         _lastLoadQueryTask = Service.Framework.Run(() => Log("Tasks kicked off"));
+    }
+
+    private void OnConfigModified()
+    {
+        if (Service.Config.MeshDirectory != _cacheDir.FullName)
+        {
+            _cacheDir = new DirectoryInfo(Service.Config.MeshDirectory);
+            _cacheDir.Create(); // ensure directory exists
+        }
+        Reload(false); // reload navmesh with new settings
     }
 
     public void Dispose()

--- a/vnavmesh/Plugin.cs
+++ b/vnavmesh/Plugin.cs
@@ -37,7 +37,7 @@ public sealed class Plugin : IDalamudPlugin
         Service.Config.Load(dalamud.ConfigFile);
         Service.Config.Modified += () => Service.Config.Save(dalamud.ConfigFile);
 
-        _navmeshManager = new(new($"{dalamud.ConfigDirectory.FullName}/meshcache"));
+        _navmeshManager = new();
         _followPath = new(dalamud, _navmeshManager);
         _asyncMove = new(_navmeshManager, _followPath);
         _dtrProvider = new(_navmeshManager, _asyncMove);


### PR DESCRIPTION
Updated NavmeshManager to dynamically use the directory from config settings, removing the requirement for an explicit constructor argument. Added UI options to configure the mesh directory with input validation and folder browsing support. Ensured backward compatibility by defaulting to the previous behavior if no valid directory is provided.