### PR TITLE
Introduce mild randomness to generated volume paths

### DIFF
--- a/vnavmesh/Config.cs
+++ b/vnavmesh/Config.cs
@@ -15,6 +15,7 @@ public class Config
     public bool ShowWaypoints;
     public bool ForceShowGameCollision;
     public bool CancelMoveOnUserInput;
+    public float RandomnessMultiplier = 5.0f;
 
     public event Action? Modified;
 
@@ -33,6 +34,8 @@ public class Config
         if (ImGui.Checkbox("Always visualize game collision", ref ForceShowGameCollision))
             NotifyModified();
         if (ImGui.Checkbox("Cancel current path on player movement input", ref CancelMoveOnUserInput))
+            NotifyModified();
+        if (ImGui.SliderFloat("Randomness Multiplier", ref RandomnessMultiplier, 0.0f, 10.0f, "%.2f"))
             NotifyModified();
     }
 

--- a/vnavmesh/Config.cs
+++ b/vnavmesh/Config.cs
@@ -15,7 +15,7 @@ public class Config
     public bool ShowWaypoints;
     public bool ForceShowGameCollision;
     public bool CancelMoveOnUserInput;
-    public float RandomnessMultiplier = 10.0f;
+    public float RandomnessMultiplier = 1f;
 
     public event Action? Modified;
 
@@ -36,7 +36,7 @@ public class Config
         if (ImGui.Checkbox("Cancel current path on player movement input", ref CancelMoveOnUserInput))
             NotifyModified();
         ImGui.SetNextItemWidth(200);
-        if (ImGui.SliderFloat("Randomness Multiplier", ref RandomnessMultiplier, 0.0f, 100.0f, "%.2f"))
+        if (ImGui.SliderFloat("Randomness Multiplier", ref RandomnessMultiplier, 0f, 1.0f, "%.2f"))
             NotifyModified();
     }
 

--- a/vnavmesh/Config.cs
+++ b/vnavmesh/Config.cs
@@ -15,7 +15,7 @@ public class Config
     public bool ShowWaypoints;
     public bool ForceShowGameCollision;
     public bool CancelMoveOnUserInput;
-    public float RandomnessMultiplier = 5.0f;
+    public float RandomnessMultiplier = 10.0f;
 
     public event Action? Modified;
 
@@ -35,7 +35,8 @@ public class Config
             NotifyModified();
         if (ImGui.Checkbox("Cancel current path on player movement input", ref CancelMoveOnUserInput))
             NotifyModified();
-        if (ImGui.SliderFloat("Randomness Multiplier", ref RandomnessMultiplier, 0.0f, 10.0f, "%.2f"))
+        ImGui.SetNextItemWidth(200);
+        if (ImGui.SliderFloat("Randomness Multiplier", ref RandomnessMultiplier, 0.0f, 100.0f, "%.2f"))
             NotifyModified();
     }
 

--- a/vnavmesh/NavVolume/VoxelPathfind.cs
+++ b/vnavmesh/NavVolume/VoxelPathfind.cs
@@ -356,20 +356,43 @@ public class VoxelPathfind
     private float CalculateGScore(ref Node parent, ulong destVoxel, Vector3 destPos, ref int parentIndex)
     {
         float randomFactor = (float)_rng.NextDouble() * Service.Config.RandomnessMultiplier;
+
+        float baseDistance;
+        float parentBaseG;
+        Vector3 fromPos;
+
         if (_useRaycast)
         {
             // check LoS from grandparent
             int grandParentIndex = parent.ParentIndex;
             ref var grandParentNode = ref NodeSpan[grandParentIndex];
             // TODO: invert LoS check to match path reconstruction step?
-            var dist = (grandParentNode.Position - destPos).LengthSquared();
-            if (dist <= _raycastLimitSq && VoxelSearch.LineOfSight(_volume, grandParentNode.Voxel, destVoxel, grandParentNode.Position, destPos))
+            var distanceSquared = (grandParentNode.Position - destPos).LengthSquared();
+            if (distanceSquared <= _raycastLimitSq && VoxelSearch.LineOfSight(_volume, grandParentNode.Voxel, destVoxel, grandParentNode.Position, destPos))
             {
                 parentIndex = grandParentIndex;
-                return grandParentNode.GScore + MathF.Sqrt(dist) + randomFactor;
+                baseDistance = MathF.Sqrt(distanceSquared);
+                parentBaseG = grandParentNode.GScore;
+                fromPos = grandParentNode.Position;
+            }
+            else
+            {
+                baseDistance = (parent.Position - destPos).Length();
+                parentBaseG = parent.GScore;
+                fromPos = parent.Position;
             }
         }
-        return parent.GScore + (parent.Position - destPos).Length() + randomFactor;
+        else
+        {
+            baseDistance = (parent.Position - destPos).Length();
+            parentBaseG = parent.GScore;
+            fromPos = parent.Position;
+        }
+
+        float verticalDifference = MathF.Abs(fromPos.Y - destPos.Y);
+        float verticalPenalty = 0.2f * verticalDifference;
+
+        return parentBaseG + baseDistance + randomFactor + verticalPenalty;
     }
 
     private float HeuristicDistance(ulong nodeVoxel, Vector3 v) => nodeVoxel != _goalVoxel ? (v - _goalPos).Length() * 0.999f : 0;

--- a/vnavmesh/NavVolume/VoxelPathfind.cs
+++ b/vnavmesh/NavVolume/VoxelPathfind.cs
@@ -352,8 +352,10 @@ public class VoxelPathfind
         }
     }
 
+    private Random _rng = new();
     private float CalculateGScore(ref Node parent, ulong destVoxel, Vector3 destPos, ref int parentIndex)
     {
+        float randomFactor = (float)_rng.NextDouble() * Service.Config.RandomnessMultiplier;
         if (_useRaycast)
         {
             // check LoS from grandparent
@@ -364,10 +366,10 @@ public class VoxelPathfind
             if (dist <= _raycastLimitSq && VoxelSearch.LineOfSight(_volume, grandParentNode.Voxel, destVoxel, grandParentNode.Position, destPos))
             {
                 parentIndex = grandParentIndex;
-                return grandParentNode.GScore + MathF.Sqrt(dist);
+                return grandParentNode.GScore + MathF.Sqrt(dist) + randomFactor;
             }
         }
-        return parent.GScore + (parent.Position - destPos).Length();
+        return parent.GScore + (parent.Position - destPos).Length() + randomFactor;
     }
 
     private float HeuristicDistance(ulong nodeVoxel, Vector3 v) => nodeVoxel != _goalVoxel ? (v - _goalPos).Length() * 0.999f : 0;


### PR DESCRIPTION
Refactored G-Score calculations for volume pathing to include a small randomization potential as well as a minor verticality penalty. The randomization factor prevents identical pathing requests from causing users to stack on top of each other and the verticality penalty tries to prevent the algorithm from flying over major obstacles when possible.