### PR TITLE
Added nodes for Winged Terror and Brain Drain to Cursed Concern

### DIFF
--- a/vnavmesh/Customizations/Z1252OccultCrescent.cs
+++ b/vnavmesh/Customizations/Z1252OccultCrescent.cs
@@ -36,5 +36,17 @@ internal class Z1252OccultCrescent : NavmeshCustomization
 
         // purple chest route
         config.AddOffMeshConnection(new Vector3(-337.27f, 47.34f, -419.95f), new Vector3(-333.29f, 7.06f, -451.97f));
+
+        // The Wanderer's Haven aetheryte platform to beach
+        config.AddOffMeshConnection(new Vector3(-175.51f, 6.5f, -607.24f), new Vector3(-183.04f, 3.85f, -607.21f));
+
+        // The Wanderer's Haven first platform to shallows (south)
+        config.AddOffMeshConnection(new Vector3(-416f, 3.8f, -562.77f), new Vector3(-439.071f, -0.3f, -556.1f));
+
+        // The Wanderer's Haven vertical path to shallows (south)
+        config.AddOffMeshConnection(new Vector3(-500.08f, 3.5f, -552.53f), new Vector3(-509.95f, -0.3f, -552.91f));
+
+        // Top of Heath Cliff (Brain Drain) to Beach (Cursed Concern)
+        config.AddOffMeshConnection(new Vector3(5.23f, 106.65f, -390.92f), new Vector3(16.14f, 25.44f, -437.46f));
     }
 }


### PR DESCRIPTION
Here are the paths visualised in blue:
![image](https://github.com/user-attachments/assets/e3b71a13-327c-4166-ad96-e6631dcdc402)

The winged terror one is designed to not be the very shortest but the most reliable, since the collision in this area can be funky