### PR TITLE
Optimize mesh pathfinding

### DIFF
--- a/vnavmesh.Benchmarks/Program.cs
+++ b/vnavmesh.Benchmarks/Program.cs
@@ -1,0 +1,562 @@
+using Navmesh;
+using Navmesh.Benchmarking;
+using Navmesh.Movement;
+using System.Diagnostics;
+using System.Globalization;
+
+if (args.Contains("--help") || args.Contains("-h"))
+{
+    BenchOptions.PrintUsage();
+    return 0;
+}
+
+var options = BenchOptions.Parse(args);
+if (options == null)
+{
+    BenchOptions.PrintUsage();
+    return 2;
+}
+
+NavmeshDiagnostics.RandomnessMultiplierProvider = () => options.RandomnessMultiplier;
+
+var metadata = BenchmarkSnapshotFiles.LoadMetadata(options.SnapshotDirectory);
+var navmesh = BenchmarkSnapshotFiles.LoadNavmesh(options.SnapshotDirectory, metadata);
+if (options.InspectCount > 0)
+{
+    InspectSnapshot(navmesh, metadata, options.InspectCount);
+    return 0;
+}
+
+var csvPrefix = options.PhaseMode ? "pathfind-phases" : "pathfind";
+var csvPath = options.CsvPath ?? Path.Combine(options.SnapshotDirectory, $"{csvPrefix}-{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}.csv");
+var cases = metadata.Pairs
+    .Select((pair, index) => new BenchCase(index, pair))
+    .Where(c => options.FlyModes.Contains(c.Pair.Fly))
+    .Where(c => !c.Pair.Fly || navmesh.Volume != null)
+    .Where(c => !options.PhaseMode || !c.Pair.Fly)
+    .ToList();
+
+if (cases.Count == 0)
+    throw new InvalidOperationException("No matching benchmark path pairs were found in the snapshot.");
+
+Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(csvPath))!);
+
+var summaries = new Dictionary<string, List<double>>();
+var successCounts = new Dictionary<string, int>();
+var totalCounts = new Dictionary<string, int>();
+var cacheHitCounts = new Dictionary<string, int>();
+
+if (options.PhaseMode)
+{
+    var phaseSummaries = new Dictionary<string, PhaseSamples>();
+
+    using var phaseWriter = new StreamWriter(csvPath);
+    phaseWriter.WriteLine("variant,iteration,pair_index,use_raycast,use_string_pulling,success,total_us,nearest_us,find_path_us,straight_path_us,waypoint_us,alloc_bytes,nearest_alloc_bytes,find_path_alloc_bytes,straight_path_alloc_bytes,waypoint_alloc_bytes,find_path_popped_nodes,find_path_touched_nodes,find_path_scanned_edges,find_path_passed_filter_edges,find_path_skipped_parent_edges,find_path_skipped_same_parent_edges,find_path_skipped_open_worse,find_path_skipped_closed_worse,find_path_portal_calls,find_path_cost_calls,find_path_heuristic_calls,find_path_heap_pushes,find_path_heap_pops,find_path_heap_modifies,find_path_max_open_list,find_path_final_cost,poly_path,straight_points,waypoints,error");
+
+    foreach (var raycast in options.RaycastModes)
+    {
+        foreach (var stringPulling in options.StringPullingModes)
+        {
+            var variant = $"raycast={raycast};string={stringPulling};h={options.MeshHeuristicScale:g}";
+            phaseSummaries[variant] = new();
+            successCounts[variant] = 0;
+            totalCounts[variant] = 0;
+
+            var query = new NavmeshQuery(navmesh);
+            query.MeshHeuristicScale = options.MeshHeuristicScale;
+            query.NearestMeshPolyCacheSize = options.NearestMeshPolyCacheSize;
+            for (var warmup = 0; warmup < options.WarmupIterations; warmup++)
+                RunPhasePass(query, cases, raycast, stringPulling, null, null, variant, warmup);
+
+            for (var iteration = 0; iteration < options.Iterations; iteration++)
+                RunPhasePass(query, cases, raycast, stringPulling, phaseWriter, phaseSummaries[variant], variant, iteration);
+        }
+    }
+
+    Console.WriteLine($"Snapshot: {options.SnapshotDirectory}");
+    Console.WriteLine($"CSV: {csvPath}");
+    Console.WriteLine($"Pairs: {cases.Count}, iterations: {options.Iterations}, phase mode: mesh");
+    foreach (var (variant, samples) in phaseSummaries)
+    {
+        samples.Sort();
+        var total = totalCounts[variant];
+        var success = successCounts[variant];
+        Console.WriteLine($"{variant}: success {success}/{total}, total median {Percentile(samples.Total, 0.50):F1}us, p95 {Percentile(samples.Total, 0.95):F1}us, p99 {Percentile(samples.Total, 0.99):F1}us");
+        Console.WriteLine($"  nearest median {Percentile(samples.Nearest, 0.50):F1}us, findPath {Percentile(samples.FindPath, 0.50):F1}us, straight {Percentile(samples.StraightPath, 0.50):F1}us, waypoint {Percentile(samples.Waypoint, 0.50):F1}us, alloc median {Percentile(samples.AllocBytes, 0.50):F0}B");
+        Console.WriteLine($"  alloc median: nearest {Percentile(samples.NearestAllocBytes, 0.50):F0}B, findPath {Percentile(samples.FindPathAllocBytes, 0.50):F0}B, straight {Percentile(samples.StraightPathAllocBytes, 0.50):F0}B, waypoint {Percentile(samples.WaypointAllocBytes, 0.50):F0}B");
+        Console.WriteLine($"  findPath work median: popped {Percentile(samples.FindPathPoppedNodes, 0.50):F0}, touched {Percentile(samples.FindPathTouchedNodes, 0.50):F0}, edges {Percentile(samples.FindPathScannedEdges, 0.50):F0}, portals {Percentile(samples.FindPathPortalCalls, 0.50):F0}, maxOpen {Percentile(samples.FindPathMaxOpenList, 0.50):F0}, cost {Percentile(samples.FindPathFinalCost, 0.50):F1}");
+    }
+
+    return 0;
+}
+
+using var writer = new StreamWriter(csvPath);
+writer.WriteLine("variant,iteration,pair_index,fly,use_raycast,use_string_pulling,success,elapsed_us,waypoints,cache_hit,error");
+
+foreach (var raycast in options.RaycastModes)
+{
+    foreach (var stringPulling in options.StringPullingModes)
+    {
+        var variant = $"raycast={raycast};string={stringPulling};h={options.MeshHeuristicScale:g};pathCache={options.MeshPathCacheSize};nearestCache={options.NearestMeshPolyCacheSize}";
+        summaries[variant] = [];
+        successCounts[variant] = 0;
+        totalCounts[variant] = 0;
+        cacheHitCounts[variant] = 0;
+
+        var query = new NavmeshQuery(navmesh);
+        query.MeshHeuristicScale = options.MeshHeuristicScale;
+        query.MeshPathCacheSize = options.MeshPathCacheSize;
+        query.NearestMeshPolyCacheSize = options.NearestMeshPolyCacheSize;
+        for (var warmup = 0; warmup < options.WarmupIterations; warmup++)
+            RunPass(query, cases, raycast, stringPulling, null, null, variant, warmup);
+
+        for (var iteration = 0; iteration < options.Iterations; iteration++)
+            RunPass(query, cases, raycast, stringPulling, writer, summaries[variant], variant, iteration);
+    }
+}
+
+Console.WriteLine($"Snapshot: {options.SnapshotDirectory}");
+Console.WriteLine($"CSV: {csvPath}");
+Console.WriteLine($"Pairs: {cases.Count}, iterations: {options.Iterations}");
+foreach (var (variant, samples) in summaries)
+{
+    samples.Sort();
+    var total = totalCounts[variant];
+    var success = successCounts[variant];
+    Console.WriteLine($"{variant}: success {success}/{total}, cache hits {cacheHitCounts[variant]}/{total}, median {Percentile(samples, 0.50):F1}us, p95 {Percentile(samples, 0.95):F1}us, p99 {Percentile(samples, 0.99):F1}us");
+}
+
+return 0;
+
+void InspectSnapshot(Navmesh.Navmesh navmesh, BenchmarkSnapshotMetadata metadata, int count)
+{
+    var query = new NavmeshQuery(navmesh);
+    var tileCount = 0;
+    var polyCount = 0;
+    for (var i = 0; i < navmesh.Mesh.GetMaxTiles(); i++)
+    {
+        var tile = navmesh.Mesh.GetTile(i);
+        if (tile?.data?.header == null)
+            continue;
+
+        tileCount++;
+        polyCount += tile.data.header.polyCount;
+    }
+
+    Console.WriteLine($"SourceKey: {metadata.SourceKey}");
+    Console.WriteLine($"TerritoryId: {metadata.TerritoryId}");
+    Console.WriteLine($"Tiles: {tileCount}/{navmesh.Mesh.GetMaxTiles()}, polys: {polyCount}, volume: {navmesh.Volume != null}");
+    Console.WriteLine($"Pairs: {metadata.Pairs.Count}");
+    for (var i = 0; i < Math.Min(count, metadata.Pairs.Count); i++)
+    {
+        var pair = metadata.Pairs[i];
+        var from = pair.From.ToVector3();
+        var to = pair.To.ToVector3();
+        if (pair.Fly)
+        {
+            var fromVoxel = query.FindNearestVolumeVoxel(from);
+            var toVoxel = query.FindNearestVolumeVoxel(to);
+            Console.WriteLine($"[{i}] fly {from} -> {to}, voxels {fromVoxel:X} -> {toVoxel:X}");
+        }
+        else
+        {
+            var fromPoly = query.FindNearestMeshPoly(from);
+            var toPoly = query.FindNearestMeshPoly(to);
+            Console.WriteLine($"[{i}] mesh {from} -> {to}, polys {fromPoly:X} -> {toPoly:X}");
+        }
+    }
+}
+
+void RunPass(
+    NavmeshQuery query,
+    IReadOnlyList<BenchCase> cases,
+    bool useRaycast,
+    bool useStringPulling,
+    StreamWriter? csv,
+    List<double>? samples,
+    string variant,
+    int iteration)
+{
+    foreach (var c in cases)
+    {
+        var from = c.Pair.From.ToVector3();
+        var to = c.Pair.To.ToVector3();
+        var start = Stopwatch.GetTimestamp();
+        var success = false;
+        var waypoints = 0;
+        var cacheHit = false;
+        var error = "";
+        try
+        {
+            List<Waypoint> path;
+            if (c.Pair.Fly)
+            {
+                path = query.PathfindVolume(from, to, useRaycast, useStringPulling, CancellationToken.None);
+            }
+            else
+            {
+                path = query.PathfindMesh(from, to, useRaycast, useStringPulling, 0, CancellationToken.None);
+                cacheHit = query.LastMeshPathCacheHit;
+            }
+            success = path.Count > 0;
+            waypoints = path.Count;
+        }
+        catch (Exception ex)
+        {
+            error = ex.GetType().Name + ": " + ex.Message;
+        }
+
+        var elapsedUs = Stopwatch.GetElapsedTime(start).TotalMilliseconds * 1000.0;
+        if (csv != null)
+        {
+            samples!.Add(elapsedUs);
+            totalCounts[variant]++;
+            if (success)
+                successCounts[variant]++;
+            if (cacheHit)
+                cacheHitCounts[variant]++;
+
+            csv.WriteLine(string.Join(',', [
+                Csv(variant),
+                iteration.ToString(CultureInfo.InvariantCulture),
+                c.Index.ToString(CultureInfo.InvariantCulture),
+                c.Pair.Fly.ToString(CultureInfo.InvariantCulture),
+                useRaycast.ToString(CultureInfo.InvariantCulture),
+                useStringPulling.ToString(CultureInfo.InvariantCulture),
+                success.ToString(CultureInfo.InvariantCulture),
+                elapsedUs.ToString("F3", CultureInfo.InvariantCulture),
+                waypoints.ToString(CultureInfo.InvariantCulture),
+                cacheHit.ToString(CultureInfo.InvariantCulture),
+                Csv(error),
+            ]));
+        }
+    }
+}
+
+void RunPhasePass(
+    NavmeshQuery query,
+    IReadOnlyList<BenchCase> cases,
+    bool useRaycast,
+    bool useStringPulling,
+    StreamWriter? csv,
+    PhaseSamples? samples,
+    string variant,
+    int iteration)
+{
+    foreach (var c in cases)
+    {
+        var from = c.Pair.From.ToVector3();
+        var to = c.Pair.To.ToVector3();
+        NavmeshQuery.MeshPathfindPhaseResult result;
+        try
+        {
+            result = query.BenchmarkPathfindMeshPhases(from, to, useRaycast, useStringPulling, 0, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            result = new(
+                false,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                ex.GetType().Name + ": " + ex.Message);
+        }
+
+        if (csv != null)
+        {
+            var totalUs = TicksToMicroseconds(result.TotalTicks);
+            var nearestUs = TicksToMicroseconds(result.NearestTicks);
+            var findPathUs = TicksToMicroseconds(result.FindPathTicks);
+            var straightPathUs = TicksToMicroseconds(result.StraightPathTicks);
+            var waypointUs = TicksToMicroseconds(result.WaypointTicks);
+
+            samples!.Total.Add(totalUs);
+            samples.Nearest.Add(nearestUs);
+            samples.FindPath.Add(findPathUs);
+            samples.StraightPath.Add(straightPathUs);
+            samples.Waypoint.Add(waypointUs);
+            samples.AllocBytes.Add(result.AllocBytes);
+            samples.NearestAllocBytes.Add(result.NearestAllocBytes);
+            samples.FindPathAllocBytes.Add(result.FindPathAllocBytes);
+            samples.StraightPathAllocBytes.Add(result.StraightPathAllocBytes);
+            samples.WaypointAllocBytes.Add(result.WaypointAllocBytes);
+            samples.FindPathPoppedNodes.Add(result.FindPathPoppedNodes);
+            samples.FindPathTouchedNodes.Add(result.FindPathTouchedNodes);
+            samples.FindPathScannedEdges.Add(result.FindPathScannedEdges);
+            samples.FindPathPortalCalls.Add(result.FindPathPortalCalls);
+            samples.FindPathMaxOpenList.Add(result.FindPathMaxOpenList);
+            samples.FindPathFinalCost.Add(result.FindPathFinalCost);
+            totalCounts[variant]++;
+            if (result.Success)
+                successCounts[variant]++;
+
+            csv.WriteLine(string.Join(',', [
+                Csv(variant),
+                iteration.ToString(CultureInfo.InvariantCulture),
+                c.Index.ToString(CultureInfo.InvariantCulture),
+                useRaycast.ToString(CultureInfo.InvariantCulture),
+                useStringPulling.ToString(CultureInfo.InvariantCulture),
+                result.Success.ToString(CultureInfo.InvariantCulture),
+                totalUs.ToString("F3", CultureInfo.InvariantCulture),
+                nearestUs.ToString("F3", CultureInfo.InvariantCulture),
+                findPathUs.ToString("F3", CultureInfo.InvariantCulture),
+                straightPathUs.ToString("F3", CultureInfo.InvariantCulture),
+                waypointUs.ToString("F3", CultureInfo.InvariantCulture),
+                result.AllocBytes.ToString(CultureInfo.InvariantCulture),
+                result.NearestAllocBytes.ToString(CultureInfo.InvariantCulture),
+                result.FindPathAllocBytes.ToString(CultureInfo.InvariantCulture),
+                result.StraightPathAllocBytes.ToString(CultureInfo.InvariantCulture),
+                result.WaypointAllocBytes.ToString(CultureInfo.InvariantCulture),
+                result.FindPathPoppedNodes.ToString(CultureInfo.InvariantCulture),
+                result.FindPathTouchedNodes.ToString(CultureInfo.InvariantCulture),
+                result.FindPathScannedEdges.ToString(CultureInfo.InvariantCulture),
+                result.FindPathPassedFilterEdges.ToString(CultureInfo.InvariantCulture),
+                result.FindPathSkippedParentEdges.ToString(CultureInfo.InvariantCulture),
+                result.FindPathSkippedSameParentEdges.ToString(CultureInfo.InvariantCulture),
+                result.FindPathSkippedOpenWorse.ToString(CultureInfo.InvariantCulture),
+                result.FindPathSkippedClosedWorse.ToString(CultureInfo.InvariantCulture),
+                result.FindPathPortalCalls.ToString(CultureInfo.InvariantCulture),
+                result.FindPathCostCalls.ToString(CultureInfo.InvariantCulture),
+                result.FindPathHeuristicCalls.ToString(CultureInfo.InvariantCulture),
+                result.FindPathHeapPushes.ToString(CultureInfo.InvariantCulture),
+                result.FindPathHeapPops.ToString(CultureInfo.InvariantCulture),
+                result.FindPathHeapModifies.ToString(CultureInfo.InvariantCulture),
+                result.FindPathMaxOpenList.ToString(CultureInfo.InvariantCulture),
+                result.FindPathFinalCost.ToString("F3", CultureInfo.InvariantCulture),
+                result.PolyPathCount.ToString(CultureInfo.InvariantCulture),
+                result.StraightPathCount.ToString(CultureInfo.InvariantCulture),
+                result.Waypoints.ToString(CultureInfo.InvariantCulture),
+                Csv(result.Error),
+            ]));
+        }
+    }
+}
+
+static double Percentile(IReadOnlyList<double> values, double percentile)
+{
+    if (values.Count == 0)
+        return 0;
+
+    var index = Math.Clamp((int)Math.Ceiling(percentile * values.Count) - 1, 0, values.Count - 1);
+    return values[index];
+}
+
+static double TicksToMicroseconds(long ticks) => ticks * 1_000_000.0 / Stopwatch.Frequency;
+
+static string Csv(string value) => '"' + value.Replace("\"", "\"\"") + '"';
+
+internal sealed record BenchCase(int Index, BenchmarkPathPair Pair);
+
+internal sealed class PhaseSamples
+{
+    public readonly List<double> Total = [];
+    public readonly List<double> Nearest = [];
+    public readonly List<double> FindPath = [];
+    public readonly List<double> StraightPath = [];
+    public readonly List<double> Waypoint = [];
+    public readonly List<double> AllocBytes = [];
+    public readonly List<double> NearestAllocBytes = [];
+    public readonly List<double> FindPathAllocBytes = [];
+    public readonly List<double> StraightPathAllocBytes = [];
+    public readonly List<double> WaypointAllocBytes = [];
+    public readonly List<double> FindPathPoppedNodes = [];
+    public readonly List<double> FindPathTouchedNodes = [];
+    public readonly List<double> FindPathScannedEdges = [];
+    public readonly List<double> FindPathPortalCalls = [];
+    public readonly List<double> FindPathMaxOpenList = [];
+    public readonly List<double> FindPathFinalCost = [];
+
+    public void Sort()
+    {
+        Total.Sort();
+        Nearest.Sort();
+        FindPath.Sort();
+        StraightPath.Sort();
+        Waypoint.Sort();
+        AllocBytes.Sort();
+        NearestAllocBytes.Sort();
+        FindPathAllocBytes.Sort();
+        StraightPathAllocBytes.Sort();
+        WaypointAllocBytes.Sort();
+        FindPathPoppedNodes.Sort();
+        FindPathTouchedNodes.Sort();
+        FindPathScannedEdges.Sort();
+        FindPathPortalCalls.Sort();
+        FindPathMaxOpenList.Sort();
+        FindPathFinalCost.Sort();
+    }
+}
+
+internal sealed class BenchOptions
+{
+    public required string SnapshotDirectory { get; init; }
+    public string? CsvPath { get; init; }
+    public int Iterations { get; init; } = 5;
+    public int WarmupIterations { get; init; } = 1;
+    public float RandomnessMultiplier { get; init; }
+    public float MeshHeuristicScale { get; init; } = 10f;
+    public int MeshPathCacheSize { get; init; } = 2048;
+    public int NearestMeshPolyCacheSize { get; init; } = 4096;
+    public IReadOnlyList<bool> RaycastModes { get; init; } = [false, true];
+    public IReadOnlyList<bool> StringPullingModes { get; init; } = [false, true];
+    public IReadOnlyList<bool> FlyModes { get; init; } = [false, true];
+    public int InspectCount { get; init; }
+    public bool PhaseMode { get; init; }
+
+    public static BenchOptions? Parse(string[] args)
+    {
+        if (args.Length == 0)
+            return null;
+
+        var snapshotDirectory = args[0];
+        string? csvPath = null;
+        var iterations = 5;
+        var warmupIterations = 1;
+        var randomnessMultiplier = 0f;
+        var meshHeuristicScale = 10f;
+        var meshPathCacheSize = 2048;
+        var nearestMeshPolyCacheSize = 4096;
+        IReadOnlyList<bool> raycastModes = [false, true];
+        IReadOnlyList<bool> stringPullingModes = [false, true];
+        IReadOnlyList<bool> flyModes = [false, true];
+        var inspectCount = 0;
+        var phaseMode = false;
+
+        for (var i = 1; i < args.Length; i++)
+        {
+            var arg = args[i];
+            string next()
+            {
+                if (++i >= args.Length)
+                    throw new ArgumentException($"Missing value after {arg}");
+                return args[i];
+            }
+
+            switch (arg)
+            {
+                case "--csv":
+                    csvPath = next();
+                    break;
+                case "--iterations":
+                    iterations = int.Parse(next(), CultureInfo.InvariantCulture);
+                    break;
+                case "--warmup":
+                    warmupIterations = int.Parse(next(), CultureInfo.InvariantCulture);
+                    break;
+                case "--randomness":
+                    randomnessMultiplier = float.Parse(next(), CultureInfo.InvariantCulture);
+                    break;
+                case "--heuristic-scale":
+                    meshHeuristicScale = float.Parse(next(), CultureInfo.InvariantCulture);
+                    break;
+                case "--mesh-cache-size":
+                    meshPathCacheSize = int.Parse(next(), CultureInfo.InvariantCulture);
+                    break;
+                case "--nearest-cache-size":
+                    nearestMeshPolyCacheSize = int.Parse(next(), CultureInfo.InvariantCulture);
+                    break;
+                case "--raycast":
+                    raycastModes = ParseBoolModes(next());
+                    break;
+                case "--string-pulling":
+                    stringPullingModes = ParseBoolModes(next());
+                    break;
+                case "--fly":
+                    flyModes = ParseBoolModes(next());
+                    break;
+                case "--inspect":
+                    inspectCount = int.Parse(next(), CultureInfo.InvariantCulture);
+                    break;
+                case "--phase":
+                    phaseMode = true;
+                    break;
+                default:
+                    throw new ArgumentException($"Unknown argument: {arg}");
+            }
+        }
+
+        return new()
+        {
+            SnapshotDirectory = snapshotDirectory,
+            CsvPath = csvPath,
+            Iterations = Math.Max(1, iterations),
+            WarmupIterations = Math.Max(0, warmupIterations),
+            RandomnessMultiplier = randomnessMultiplier,
+            MeshHeuristicScale = Math.Max(0.01f, meshHeuristicScale),
+            MeshPathCacheSize = Math.Max(0, meshPathCacheSize),
+            NearestMeshPolyCacheSize = Math.Max(0, nearestMeshPolyCacheSize),
+            RaycastModes = raycastModes,
+            StringPullingModes = stringPullingModes,
+            FlyModes = flyModes,
+            InspectCount = Math.Max(0, inspectCount),
+            PhaseMode = phaseMode,
+        };
+    }
+
+    public static void PrintUsage()
+    {
+        Console.WriteLine("Usage:");
+        Console.WriteLine("  dotnet run --project vnavmesh.Benchmarks -- <snapshot-dir> [options]");
+        Console.WriteLine();
+        Console.WriteLine("Options:");
+        Console.WriteLine("  --iterations <n>          Measured passes over all pairs. Default: 5");
+        Console.WriteLine("  --warmup <n>              Warmup passes. Default: 1");
+        Console.WriteLine("  --csv <path>              Output CSV path. Default: snapshot-dir/pathfind-*.csv");
+        Console.WriteLine("  --raycast true|false|both Default: both");
+        Console.WriteLine("  --string-pulling true|false|both Default: both");
+        Console.WriteLine("  --fly true|false|both     Default: both");
+        Console.WriteLine("  --randomness <value>      Voxel path randomness multiplier. Default: 0");
+        Console.WriteLine("  --heuristic-scale <value> Mesh A* heuristic multiplier. Default: 10");
+        Console.WriteLine("  --mesh-cache-size <n>     Mesh polygon path cache entries in normal mode. Default: 2048, 0 disables");
+        Console.WriteLine("  --nearest-cache-size <n>  Exact nearest-poly cache entries. Default: 4096, 0 disables");
+        Console.WriteLine("  --inspect <n>             Print navmesh and first n pair refs, then exit");
+        Console.WriteLine("  --phase                   Measure mesh pathfinding phases and allocations");
+    }
+
+    private static IReadOnlyList<bool> ParseBoolModes(string value)
+    {
+        return value.ToLowerInvariant() switch
+        {
+            "true" or "yes" or "1" => [true],
+            "false" or "no" or "0" => [false],
+            "both" or "all" => [false, true],
+            _ => throw new ArgumentException($"Expected true, false, or both; got '{value}'"),
+        };
+    }
+
+    private static bool ParseBool(string value)
+    {
+        return value.ToLowerInvariant() switch
+        {
+            "true" or "yes" or "1" => true,
+            "false" or "no" or "0" => false,
+            _ => throw new ArgumentException($"Expected true or false; got '{value}'"),
+        };
+    }
+}

--- a/vnavmesh.Benchmarks/vnavmesh.Benchmarks.csproj
+++ b/vnavmesh.Benchmarks/vnavmesh.Benchmarks.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DotRecast\src\DotRecast.Core\DotRecast.Core.csproj" />
+    <ProjectReference Include="..\DotRecast\src\DotRecast.Detour\DotRecast.Detour.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\vnavmesh\Benchmarking\BenchmarkSnapshot.cs" Link="Shared\Benchmarking\BenchmarkSnapshot.cs" />
+    <Compile Include="..\vnavmesh\Diagnostics\NavmeshDiagnostics.cs" Link="Shared\Diagnostics\NavmeshDiagnostics.cs" />
+    <Compile Include="..\vnavmesh\Extensions.cs" Link="Shared\Extensions.cs" />
+    <Compile Include="..\vnavmesh\Movement\Waypoint.cs" Link="Shared\Movement\Waypoint.cs" />
+    <Compile Include="..\vnavmesh\Navmesh.cs" Link="Shared\Navmesh.cs" />
+    <Compile Include="..\vnavmesh\NavmeshQuery.cs" Link="Shared\NavmeshQuery.cs" />
+    <Compile Include="..\vnavmesh\NavVolume\VoxelMap.cs" Link="Shared\NavVolume\VoxelMap.cs" />
+    <Compile Include="..\vnavmesh\NavVolume\VoxelPathfind.cs" Link="Shared\NavVolume\VoxelPathfind.cs" />
+    <Compile Include="..\vnavmesh\NavVolume\VoxelSearch.cs" Link="Shared\NavVolume\VoxelSearch.cs" />
+    <Compile Include="..\vnavmesh\NavVolume\Voxelizer.cs" Link="Shared\NavVolume\Voxelizer.cs" />
+    <Compile Include="..\vnavmesh\Timer.cs" Link="Shared\Timer.cs" />
+  </ItemGroup>
+</Project>

--- a/vnavmesh.sln
+++ b/vnavmesh.sln
@@ -19,6 +19,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotRecast.Detour.Extras", "DotRecast\src\DotRecast.Detour.Extras\DotRecast.Detour.Extras.csproj", "{55E26212-7003-F164-4095-7C1D49BE99ED}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "vnavmesh.Benchmarks", "vnavmesh.Benchmarks\vnavmesh.Benchmarks.csproj", "{0CDDD6E9-046A-4DF6-BC36-9E13C60BA2A0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -75,6 +77,14 @@ Global
 		{55E26212-7003-F164-4095-7C1D49BE99ED}.Release|Any CPU.Build.0 = Release|Any CPU
 		{55E26212-7003-F164-4095-7C1D49BE99ED}.Release|x64.ActiveCfg = Release|Any CPU
 		{55E26212-7003-F164-4095-7C1D49BE99ED}.Release|x64.Build.0 = Release|Any CPU
+		{0CDDD6E9-046A-4DF6-BC36-9E13C60BA2A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0CDDD6E9-046A-4DF6-BC36-9E13C60BA2A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0CDDD6E9-046A-4DF6-BC36-9E13C60BA2A0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0CDDD6E9-046A-4DF6-BC36-9E13C60BA2A0}.Debug|x64.Build.0 = Debug|Any CPU
+		{0CDDD6E9-046A-4DF6-BC36-9E13C60BA2A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0CDDD6E9-046A-4DF6-BC36-9E13C60BA2A0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0CDDD6E9-046A-4DF6-BC36-9E13C60BA2A0}.Release|x64.ActiveCfg = Release|Any CPU
+		{0CDDD6E9-046A-4DF6-BC36-9E13C60BA2A0}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/vnavmesh/Benchmarking/BenchmarkCapture.cs
+++ b/vnavmesh/Benchmarking/BenchmarkCapture.cs
@@ -1,0 +1,127 @@
+using DotRecast.Detour;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Numerics;
+
+namespace Navmesh.Benchmarking;
+
+internal static class BenchmarkCapture
+{
+    private const int DefaultSeed = 0x6E61766D; // "navm"
+
+    public static string Capture(NavmeshManager manager, string configDirectory, string name, int pairsPerMode)
+    {
+        if (manager.Navmesh == null)
+            throw new InvalidOperationException("Navmesh is not loaded");
+
+        pairsPerMode = Math.Clamp(pairsPerMode, 1, 10_000);
+
+        var random = new Random(DefaultSeed);
+        var pairs = new List<BenchmarkPathPair>();
+        AddMeshPairs(pairs, manager.Navmesh, random, pairsPerMode);
+        AddVolumePairs(pairs, manager.Navmesh, random, pairsPerMode);
+
+        var safeName = SanitizeName(string.IsNullOrWhiteSpace(name) ? DateTime.UtcNow.ToString("yyyyMMdd-HHmmss") : name);
+        var directory = Path.Combine(configDirectory, "benchmarks", safeName);
+        var metadata = new BenchmarkSnapshotMetadata
+        {
+            SourceKey = manager.CurrentKey,
+            TerritoryId = Service.ClientState.TerritoryType,
+            CustomizationVersion = manager.Navmesh.CustomizationVersion,
+            PairSeed = DefaultSeed,
+            RequestedPairsPerMode = pairsPerMode,
+            Pairs = pairs,
+        };
+
+        BenchmarkSnapshotFiles.Save(directory, metadata, manager.Navmesh);
+        return directory;
+    }
+
+    private static void AddMeshPairs(List<BenchmarkPathPair> pairs, Navmesh navmesh, Random random, int count)
+    {
+        var points = CollectMeshPoints(navmesh.Mesh);
+        AddPairs(pairs, points, random, count, false);
+    }
+
+    private static List<Vector3> CollectMeshPoints(DtNavMesh mesh)
+    {
+        var points = new List<Vector3>();
+        for (var i = 0; i < mesh.GetMaxTiles(); i++)
+        {
+            var tile = mesh.GetTile(i);
+            if (tile?.data?.header == null)
+                continue;
+
+            var polyBase = mesh.GetPolyRefBase(tile);
+            for (var j = 0; j < tile.data.header.polyCount; j++)
+            {
+                var poly = tile.data.polys[j];
+                if (poly.GetPolyType() != DtPolyTypes.DT_POLYTYPE_GROUND)
+                    continue;
+                if ((poly.flags & Navmesh.FLAG_UNREACHABLE) != 0)
+                    continue;
+
+                points.Add(mesh.GetPolyCenter(polyBase | (uint)j).RecastToSystem());
+            }
+        }
+
+        return points;
+    }
+
+    private static void AddVolumePairs(List<BenchmarkPathPair> pairs, Navmesh navmesh, Random random, int count)
+    {
+        if (navmesh.Volume == null)
+            return;
+
+        var volume = navmesh.Volume;
+        var points = new List<Vector3>();
+        var seen = new HashSet<ulong>();
+        var min = volume.RootTile.BoundsMin;
+        var max = volume.RootTile.BoundsMax;
+        var attempts = Math.Max(10_000, count * 300);
+        while (points.Count < count * 2 && attempts-- > 0)
+        {
+            var p = new Vector3(
+                Lerp(random, min.X, max.X),
+                Lerp(random, min.Y, max.Y),
+                Lerp(random, min.Z, max.Z));
+            var (voxel, empty) = volume.FindLeafVoxel(p);
+            if (!empty || !seen.Add(voxel))
+                continue;
+
+            var (vmin, vmax) = volume.VoxelBounds(voxel, 0.1f);
+            points.Add((vmin + vmax) * 0.5f);
+        }
+
+        AddPairs(pairs, points, random, count, true);
+    }
+
+    private static void AddPairs(List<BenchmarkPathPair> pairs, IReadOnlyList<Vector3> points, Random random, int count, bool fly)
+    {
+        if (points.Count < 2)
+            return;
+
+        for (var i = 0; i < count; i++)
+        {
+            var a = random.Next(points.Count);
+            var b = random.Next(points.Count - 1);
+            if (b >= a)
+                b++;
+
+            pairs.Add(new(
+                BenchmarkPoint.FromVector3(points[a]),
+                BenchmarkPoint.FromVector3(points[b]),
+                fly));
+        }
+    }
+
+    private static float Lerp(Random random, float min, float max) => min + (max - min) * (float)random.NextDouble();
+
+    private static string SanitizeName(string name)
+    {
+        foreach (var c in Path.GetInvalidFileNameChars())
+            name = name.Replace(c, '_');
+        return name;
+    }
+}

--- a/vnavmesh/Benchmarking/BenchmarkSnapshot.cs
+++ b/vnavmesh/Benchmarking/BenchmarkSnapshot.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Numerics;
+using System.Text.Json;
+
+namespace Navmesh.Benchmarking;
+
+public readonly record struct BenchmarkPoint(float X, float Y, float Z)
+{
+    public static BenchmarkPoint FromVector3(Vector3 v) => new(v.X, v.Y, v.Z);
+    public Vector3 ToVector3() => new(X, Y, Z);
+}
+
+public sealed record BenchmarkPathPair(BenchmarkPoint From, BenchmarkPoint To, bool Fly);
+
+public sealed record BenchmarkSnapshotMetadata
+{
+    public int FormatVersion { get; init; } = 1;
+    public string CapturedAtUtc { get; init; } = DateTime.UtcNow.ToString("O");
+    public string SourceKey { get; init; } = "";
+    public uint TerritoryId { get; init; }
+    public int CustomizationVersion { get; init; }
+    public int NavmeshFormatVersion { get; init; } = (int)global::Navmesh.Navmesh.Version;
+    public int PairSeed { get; init; }
+    public int RequestedPairsPerMode { get; init; }
+    public List<BenchmarkPathPair> Pairs { get; init; } = [];
+}
+
+public static class BenchmarkSnapshotFiles
+{
+    public const string MetadataFileName = "metadata.json";
+    public const string NavmeshFileName = "navmesh.navmesh";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+    };
+
+    public static void Save(string directory, BenchmarkSnapshotMetadata metadata, global::Navmesh.Navmesh navmesh)
+    {
+        Directory.CreateDirectory(directory);
+
+        var metadataPath = Path.Combine(directory, MetadataFileName);
+        File.WriteAllText(metadataPath, JsonSerializer.Serialize(metadata, JsonOptions));
+
+        var navmeshPath = Path.Combine(directory, NavmeshFileName);
+        using var stream = File.Open(navmeshPath, FileMode.Create, FileAccess.Write, FileShare.None);
+        using var writer = new BinaryWriter(stream);
+        navmesh.Serialize(writer);
+    }
+
+    public static BenchmarkSnapshotMetadata LoadMetadata(string directory)
+    {
+        var metadataPath = Path.Combine(directory, MetadataFileName);
+        var metadata = JsonSerializer.Deserialize<BenchmarkSnapshotMetadata>(File.ReadAllText(metadataPath), JsonOptions);
+        return metadata ?? throw new InvalidDataException($"Failed to read benchmark metadata from '{metadataPath}'");
+    }
+
+    public static global::Navmesh.Navmesh LoadNavmesh(string directory, BenchmarkSnapshotMetadata metadata)
+    {
+        var navmeshPath = Path.Combine(directory, NavmeshFileName);
+        using var stream = File.OpenRead(navmeshPath);
+        using var reader = new BinaryReader(stream);
+        return global::Navmesh.Navmesh.Deserialize(reader, metadata.CustomizationVersion);
+    }
+}

--- a/vnavmesh/Config.cs
+++ b/vnavmesh/Config.cs
@@ -24,6 +24,9 @@ public class Config
     public int StuckTimeoutMs = 500;
     public bool RetryOnStuck = true;
     public float RandomnessMultiplier = 1f;
+    public float MeshHeuristicScale = 10f;
+    public int MeshPathCacheSize = 2048;
+    public int NearestMeshPolyCacheSize = 4096;
     public int BuildMaxCores = 1;
 
     private static readonly int realMaxCores = Environment.ProcessorCount;
@@ -83,6 +86,24 @@ public class Config
         ImGui.SetNextItemWidth(200);
         if (ImGui.SliderFloat("Randomness Multiplier", ref RandomnessMultiplier, 0f, 1.0f, "%.2f"))
             NotifyModified();
+
+        ImGui.SetNextItemWidth(200);
+        if (ImGui.SliderFloat("Mesh heuristic scale", ref MeshHeuristicScale, 1f, 10f, "%.1f"))
+        {
+            MeshHeuristicScale = Math.Clamp(MeshHeuristicScale, 0.01f, 20f);
+            NotifyModified();
+        }
+        ImGuiComponents.HelpMarker("1 = old conservative A* behavior; higher values reduce mesh exploration but can choose a slightly different route. Default: 10.");
+
+        ImGui.SetNextItemWidth(200);
+        if (ImGui.SliderInt("Mesh path cache size", ref MeshPathCacheSize, 0, 8192))
+            NotifyModified();
+        ImGuiComponents.HelpMarker("Caches polygon paths for repeated mesh queries with the same start and end polygons. 0 disables the cache.");
+
+        ImGui.SetNextItemWidth(200);
+        if (ImGui.SliderInt("Nearest mesh poly cache size", ref NearestMeshPolyCacheSize, 0, 8192))
+            NotifyModified();
+        ImGuiComponents.HelpMarker("Caches exact repeated nearest-poly lookups. 0 disables the cache.");
     }
 
     public void Save(FileInfo file)

--- a/vnavmesh/Debug/DebugNavmeshManager.cs
+++ b/vnavmesh/Debug/DebugNavmeshManager.cs
@@ -80,7 +80,8 @@ class DebugNavmeshManager : IDisposable
 			ExportBitmap(_manager.Navmesh, _manager.Query, playerPos);
 
 		ImGui.Checkbox("Allow movement", ref _path.MovementAllowed);
-		ImGui.Checkbox("Use raycasts", ref _manager.UseRaycasts);
+		ImGui.Checkbox("Use mesh raycasts", ref _manager.UseMeshRaycasts);
+		ImGui.Checkbox("Use volume raycasts", ref _manager.UseVolumeRaycasts);
 		ImGui.Checkbox("Use string pulling", ref _manager.UseStringPulling);
 		if (ImGui.Button("Pathfind to target using navmesh"))
 			_asyncMove.MoveTo(_target, false);

--- a/vnavmesh/Diagnostics/NavmeshDiagnostics.cs
+++ b/vnavmesh/Diagnostics/NavmeshDiagnostics.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Navmesh;
+
+public static class NavmeshDiagnostics
+{
+    public static Action<string>? DebugSink { get; set; }
+    public static Action<string>? InfoSink { get; set; }
+    public static Action<string>? ErrorSink { get; set; }
+    public static Func<float> RandomnessMultiplierProvider { get; set; } = static () => 1f;
+
+    public static float RandomnessMultiplier => RandomnessMultiplierProvider();
+    public static bool IsDebugEnabled => DebugSink != null;
+
+    public static void Debug(string message) => DebugSink?.Invoke(message);
+    public static void Info(string message) => InfoSink?.Invoke(message);
+    public static void Error(string message) => ErrorSink?.Invoke(message);
+}

--- a/vnavmesh/Movement/FollowPath.cs
+++ b/vnavmesh/Movement/FollowPath.cs
@@ -8,11 +8,6 @@ using System.Numerics;
 
 namespace Navmesh.Movement;
 
-public readonly record struct Waypoint(Vector3 Position, Navmesh.AreaId Type)
-{
-	public Waypoint(Vector3 Position) : this(Position, Navmesh.AreaId.Default) { }
-}
-
 public class FollowPath : IDisposable
 {
 	public bool MovementAllowed = true;

--- a/vnavmesh/Movement/Waypoint.cs
+++ b/vnavmesh/Movement/Waypoint.cs
@@ -1,0 +1,8 @@
+using System.Numerics;
+
+namespace Navmesh.Movement;
+
+public readonly record struct Waypoint(Vector3 Position, Navmesh.AreaId Type)
+{
+    public Waypoint(Vector3 Position) : this(Position, Navmesh.AreaId.Default) { }
+}

--- a/vnavmesh/NavVolume/VoxelPathfind.cs
+++ b/vnavmesh/NavVolume/VoxelPathfind.cs
@@ -53,7 +53,7 @@ public class VoxelPathfind
         _bestNodeIndex = 0;
         if (fromVoxel == VoxelMap.InvalidVoxel || toVoxel == VoxelMap.InvalidVoxel)
         {
-            Service.Log.Error($"Bad input cells: {fromVoxel:X} -> {toVoxel:X}");
+            NavmeshDiagnostics.Error($"Bad input cells: {fromVoxel:X} -> {toVoxel:X}");
             return;
         }
 
@@ -355,7 +355,7 @@ public class VoxelPathfind
     private Random _rng = new();
     private float CalculateGScore(ref Node parent, ulong destVoxel, Vector3 destPos, ref int parentIndex)
     {
-        float randomFactor = (float)_rng.NextDouble() * Service.Config.RandomnessMultiplier;
+        float randomFactor = (float)_rng.NextDouble() * NavmeshDiagnostics.RandomnessMultiplier;
 
         float baseDistance;
         float parentBaseG;

--- a/vnavmesh/Navmesh.cs
+++ b/vnavmesh/Navmesh.cs
@@ -74,7 +74,15 @@ public record class Navmesh(int CustomizationVersion, DtNavMesh Mesh, VoxelMap? 
 
 	private static void SerializeMesh(BinaryWriter writer, DtNavMesh mesh)
 	{
-		writer.Write(mesh.GetTileCount());
+		var numTiles = 0;
+		for (int i = 0; i < mesh.GetMaxTiles(); ++i)
+		{
+			DtMeshTile tile = mesh.GetTile(i);
+			if (tile?.data?.header != null)
+				numTiles++;
+		}
+
+		writer.Write(numTiles);
 		SerializeMeshParams(writer, mesh.GetParams());
 		writer.Write(mesh.GetMaxVertsPerPoly());
 

--- a/vnavmesh/NavmeshManager.cs
+++ b/vnavmesh/NavmeshManager.cs
@@ -16,7 +16,8 @@ namespace Navmesh;
 // manager that loads navmesh matching current zone and performs async pathfinding queries
 public sealed class NavmeshManager : IDisposable
 {
-	public bool UseRaycasts = true;
+	public bool UseMeshRaycasts = false;
+	public bool UseVolumeRaycasts = true;
 	public bool UseStringPulling = true;
 
 	public string CurrentKey { get; private set; } = ""; // unique string representing currently loaded navmesh
@@ -106,7 +107,12 @@ public sealed class NavmeshManager : IDisposable
 				var navmesh = await Task.Run(() => BuildNavmesh(scene, cacheKey, allowLoadFromCache, cancel), cancel);
 				Log($"Mesh loaded: '{cacheKey}'");
 				Navmesh = navmesh;
-				Query = new(Navmesh);
+				Query = new(Navmesh)
+				{
+					MeshHeuristicScale = Service.Config.MeshHeuristicScale,
+					MeshPathCacheSize = Service.Config.MeshPathCacheSize,
+					NearestMeshPolyCacheSize = Service.Config.NearestMeshPolyCacheSize
+				};
 
 				var ff = await FloodFill.GetAsync();
 				if (ff.TryLookup(scene.TerritoryID, out var points))
@@ -121,7 +127,12 @@ public sealed class NavmeshManager : IDisposable
 	internal void ReplaceMesh(Navmesh mesh)
 	{
 		Navmesh = mesh;
-		Query = new(Navmesh);
+		Query = new(Navmesh)
+		{
+			MeshHeuristicScale = Service.Config.MeshHeuristicScale,
+			MeshPathCacheSize = Service.Config.MeshPathCacheSize,
+			NearestMeshPolyCacheSize = Service.Config.NearestMeshPolyCacheSize
+		};
 		Log($"Mesh replaced");
 		OnNavmeshChanged?.Invoke(Navmesh, Query);
 	}
@@ -140,16 +151,22 @@ public sealed class NavmeshManager : IDisposable
 		{
 			using var autoDisposeCombined = combined;
 			using var autoDecrementCounter = new OnDispose(() => --_numActivePathfinds);
-			LogInfo($"Kicking off pathfind from {from} to {to}");
+			if (NavmeshDiagnostics.IsDebugEnabled)
+				Log($"Kicking off pathfind from {from} to {to}");
 			var path = await Task.Run(() =>
 			{
 				combined.Token.ThrowIfCancellationRequested();
 				if (Query == null)
 					throw new Exception($"Can't pathfind, navmesh did not build successfully");
-				Log($"Executing pathfind from {from} to {to}");
-				return flying ? Query.PathfindVolume(from, to, UseRaycasts, UseStringPulling, combined.Token) : Query.PathfindMesh(from, to, UseRaycasts, UseStringPulling, range, combined.Token);
+				Query.MeshHeuristicScale = Service.Config.MeshHeuristicScale;
+				Query.MeshPathCacheSize = Service.Config.MeshPathCacheSize;
+				Query.NearestMeshPolyCacheSize = Service.Config.NearestMeshPolyCacheSize;
+				if (NavmeshDiagnostics.IsDebugEnabled)
+					Log($"Executing pathfind from {from} to {to}");
+				return flying ? Query.PathfindVolume(from, to, UseVolumeRaycasts, UseStringPulling, combined.Token) : Query.PathfindMesh(from, to, UseMeshRaycasts, UseStringPulling, range, combined.Token);
 			}, combined.Token);
-			Log($"Pathfinding done: {path.Count} waypoints");
+			if (NavmeshDiagnostics.IsDebugEnabled)
+				Log($"Pathfinding done: {path.Count} waypoints");
 			return path;
 		}, combined.Token);
 	}
@@ -353,7 +370,6 @@ public sealed class NavmeshManager : IDisposable
 	}
 
 	private static void Log(string message) => Service.Log.Debug($"[NavmeshManager] [{Environment.CurrentManagedThreadId}] {message}");
-	private static void LogInfo(string message) => Service.Log.Info($"[NavmeshManager] [{Environment.CurrentManagedThreadId}] {message}");
 	private static void LogTaskError(Task task)
 	{
 		if (task.IsFaulted)

--- a/vnavmesh/NavmeshQuery.cs
+++ b/vnavmesh/NavmeshQuery.cs
@@ -2,7 +2,9 @@
 using DotRecast.Detour;
 using Navmesh.Movement;
 using Navmesh.NavVolume;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
 using System.Threading;
@@ -11,6 +13,39 @@ namespace Navmesh;
 
 public class NavmeshQuery
 {
+	public readonly record struct MeshPathfindPhaseResult(
+		bool Success,
+		int Waypoints,
+		int PolyPathCount,
+		int StraightPathCount,
+		long TotalTicks,
+		long NearestTicks,
+		long FindPathTicks,
+		long StraightPathTicks,
+		long WaypointTicks,
+		long AllocBytes,
+		long NearestAllocBytes,
+		long FindPathAllocBytes,
+		long StraightPathAllocBytes,
+		long WaypointAllocBytes,
+		int FindPathPoppedNodes,
+		int FindPathTouchedNodes,
+		int FindPathScannedEdges,
+		int FindPathPassedFilterEdges,
+		int FindPathSkippedParentEdges,
+		int FindPathSkippedSameParentEdges,
+		int FindPathSkippedOpenWorse,
+		int FindPathSkippedClosedWorse,
+		int FindPathPortalCalls,
+		int FindPathCostCalls,
+		int FindPathHeuristicCalls,
+		int FindPathHeapPushes,
+		int FindPathHeapPops,
+		int FindPathHeapModifies,
+		int FindPathMaxOpenList,
+		float FindPathFinalCost,
+		string Error);
+
 	private class IntersectQuery : IDtPolyQuery
 	{
 		public readonly List<long> Result = [];
@@ -19,28 +54,38 @@ public class NavmeshQuery
 
 	public class GoalRadiusHeuristic(float tolerance) : IDtQueryHeuristic
 	{
+		public float Scale = 1;
+
 		float IDtQueryHeuristic.GetCost(RcVec3f neighbourPos, RcVec3f endPos)
 		{
-			var dist = RcVec3f.Distance(neighbourPos, endPos) * DtDefaultQueryHeuristic.H_SCALE;
-			return dist < tolerance ? -1 : dist;
+			var dist = RcVec3f.Distance(neighbourPos, endPos);
+			return dist * DtDefaultQueryHeuristic.H_SCALE < tolerance ? -1 : dist * DtDefaultQueryHeuristic.H_SCALE * Scale;
+		}
+	}
+
+	public class ScaledQueryHeuristic(float scale) : IDtQueryHeuristic
+	{
+		public float Scale = scale;
+
+		float IDtQueryHeuristic.GetCost(RcVec3f neighbourPos, RcVec3f endPos)
+		{
+			return RcVec3f.Distance(neighbourPos, endPos) * DtDefaultQueryHeuristic.H_SCALE * Scale;
 		}
 	}
 
 	public class TeleportAwareFilter : IDtQueryFilter
 	{
-		private readonly DtQueryDefaultFilter _f = new();
-
 		public float GetCost(RcVec3f pa, RcVec3f pb, long prevRef, DtMeshTile prevTile, DtPoly prevPoly, long curRef, DtMeshTile curTile, DtPoly curPoly, long nextRef, DtMeshTile nextTile, DtPoly nextPoly)
 		{
-			var cst = _f.GetCost(pa, pb, prevRef, prevTile, prevPoly, curRef, curTile, curPoly, nextRef, nextTile, nextPoly);
+			var cst = RcVec3f.Distance(pa, pb);
 
 			var costMulti = 10f;
 
-			var curArea = (Navmesh.AreaId)curPoly.GetArea();
-			var nextArea = (Navmesh.AreaId)(nextPoly?.GetArea() ?? 0);
+			var curArea = curPoly.GetArea();
+			var nextArea = nextPoly?.GetArea() ?? 0;
 
-			if ((curArea ^ nextArea) == Navmesh.AreaId.Endpoint)
-				costMulti = curArea switch
+			if ((curArea ^ nextArea) == (int)Navmesh.AreaId.Endpoint)
+				costMulti = (Navmesh.AreaId)curArea switch
 				{
 					Navmesh.AreaId.Warp => 1,
 					Navmesh.AreaId.ClientPath => 3,
@@ -63,14 +108,74 @@ public class NavmeshQuery
 		}
 	}
 
+	private readonly record struct MeshPathCacheKey(long StartRef, long EndRef, int HeuristicScaleBits);
+	private readonly record struct NearestMeshPolyCacheKey(int X, int Y, int Z, int HalfExtentXz, int HalfExtentY, bool AllowUnreachable);
+
+	private sealed class MeshPathCacheEntry(MeshPathCacheKey key, List<long> path)
+	{
+		public readonly MeshPathCacheKey Key = key;
+		public readonly List<long> Path = path;
+	}
+
+	private sealed class NearestMeshPolyCacheEntry(NearestMeshPolyCacheKey key, long poly)
+	{
+		public readonly NearestMeshPolyCacheKey Key = key;
+		public long Poly = poly;
+	}
+
 	public DtNavMeshQuery MeshQuery;
 	public VoxelPathfind? VolumeQuery;
 	private readonly IDtQueryFilter _filter = new DtQueryDefaultFilter();
 	private readonly IDtQueryFilter _pathFilter = new TeleportAwareFilter();
 	private readonly IDtQueryFilter _reachableFilter = new FloodFillAwareFilter();
+	private readonly ScaledQueryHeuristic _pathHeuristic = new(10);
+	private readonly Dictionary<MeshPathCacheKey, LinkedListNode<MeshPathCacheEntry>> _meshPathCache = [];
+	private readonly LinkedList<MeshPathCacheEntry> _meshPathCacheLru = [];
+	private readonly Dictionary<NearestMeshPolyCacheKey, LinkedListNode<NearestMeshPolyCacheEntry>> _nearestMeshPolyCache = [];
+	private readonly LinkedList<NearestMeshPolyCacheEntry> _nearestMeshPolyCacheLru = [];
 
 	public List<long> LastPath => _lastPath;
 	private List<long> _lastPath = [];
+	private List<DtStraightPath> _straightPath = [];
+	private float _meshHeuristicScale = 10;
+	private int _meshPathCacheSize = 2048;
+	private int _nearestMeshPolyCacheSize = 4096;
+
+	public float MeshHeuristicScale
+	{
+		get => _meshHeuristicScale;
+		set
+		{
+			_meshHeuristicScale = Math.Max(0.01f, value);
+			_pathHeuristic.Scale = _meshHeuristicScale;
+		}
+	}
+
+	public int MeshPathCacheSize
+	{
+		get => _meshPathCacheSize;
+		set
+		{
+			_meshPathCacheSize = Math.Max(0, value);
+			TrimMeshPathCache();
+		}
+	}
+
+	public int NearestMeshPolyCacheSize
+	{
+		get => _nearestMeshPolyCacheSize;
+		set
+		{
+			_nearestMeshPolyCacheSize = Math.Max(0, value);
+			TrimNearestMeshPolyCache();
+		}
+	}
+
+	public bool LastMeshPathCacheHit { get; private set; }
+	public long MeshPathCacheHits { get; private set; }
+	public long MeshPathCacheMisses { get; private set; }
+	public long NearestMeshPolyCacheHits { get; private set; }
+	public long NearestMeshPolyCacheMisses { get; private set; }
 
 	public NavmeshQuery(Navmesh navmesh)
 	{
@@ -81,28 +186,48 @@ public class NavmeshQuery
 
 	public List<Waypoint> PathfindMesh(Vector3 from, Vector3 to, bool useRaycast, bool useStringPulling, float range, CancellationToken cancel)
 	{
-		var startRef = FindNearestMeshPoly(from);
-		var endRef = FindNearestMeshPoly(to);
-		Service.Log.Debug($"[pathfind] poly {startRef:X} -> {endRef:X}");
+		var startPos = from.SystemToRecast();
+		var targetPos = to.SystemToRecast();
+		var startRef = FindNearestMeshPoly(startPos);
+		var endRef = FindNearestMeshPoly(targetPos);
+		if (NavmeshDiagnostics.IsDebugEnabled)
+			NavmeshDiagnostics.Debug($"[pathfind] poly {startRef:X} -> {endRef:X}");
 		if (startRef == 0 || endRef == 0)
 		{
-			Service.Log.Error($"Failed to find a path from {from} ({startRef:X}) to {to} ({endRef:X}): failed to find polygon on a mesh");
+			NavmeshDiagnostics.Error($"Failed to find a path from {from} ({startRef:X}) to {to} ({endRef:X}): failed to find polygon on a mesh");
 			return [];
 		}
 
-		var timer = Timer.Create();
+		var debugEnabled = NavmeshDiagnostics.IsDebugEnabled;
+		var timer = debugEnabled ? Timer.Create() : default;
 		_lastPath.Clear();
-		var opt = new DtFindPathOption(range > 0 ? new GoalRadiusHeuristic(range) : DtDefaultQueryHeuristic.Default, useRaycast ? DtFindPathOptions.DT_FINDPATH_ANY_ANGLE : 0, useRaycast ? float.MaxValue : 0);
-		MeshQuery.FindPath(startRef, endRef, from.SystemToRecast(), to.SystemToRecast(), _pathFilter, ref _lastPath, opt);
+		LastMeshPathCacheHit = false;
+		var canUsePathCache = !useRaycast && range <= 0 && MeshPathCacheSize > 0;
+		if (canUsePathCache && TryGetCachedMeshPath(startRef, endRef, _lastPath))
+		{
+			LastMeshPathCacheHit = true;
+			MeshPathCacheHits++;
+		}
+		else
+		{
+			if (canUsePathCache)
+				MeshPathCacheMisses++;
+			IDtQueryHeuristic heuristic = range > 0 ? new GoalRadiusHeuristic(range) { Scale = MeshHeuristicScale } : _pathHeuristic;
+			var opt = new DtFindPathOption(heuristic, useRaycast ? DtFindPathOptions.DT_FINDPATH_ANY_ANGLE : 0, useRaycast ? float.MaxValue : 0);
+			MeshQuery.FindPath(startRef, endRef, startPos, targetPos, _pathFilter, ref _lastPath, opt);
+			if (canUsePathCache && _lastPath.Count > 0)
+				StoreCachedMeshPath(startRef, endRef, _lastPath);
+		}
 		if (_lastPath.Count == 0)
 		{
-			Service.Log.Error($"Failed to find a path from {from} ({startRef:X}) to {to} ({endRef:X}): failed to find path on mesh");
+			NavmeshDiagnostics.Error($"Failed to find a path from {from} ({startRef:X}) to {to} ({endRef:X}): failed to find path on mesh");
 			return [];
 		}
-		Service.Log.Debug($"Pathfind took {timer.Value().TotalSeconds:f3}s: {string.Join(", ", _lastPath.Select(r => r.ToString("X")))}");
+		if (debugEnabled)
+			NavmeshDiagnostics.Debug($"Pathfind took {timer.Value().TotalSeconds:f3}s: {string.Join(", ", _lastPath.Select(r => r.ToString("X")))}");
 
 		// In case of partial path, make sure the end point is clamped to the last polygon.
-		var endPos = to.SystemToRecast();
+		var endPos = targetPos;
 		//if (polysPath.Last() != endRef)
 		//    if (MeshQuery.ClosestPointOnPoly(polysPath.Last(), endPos, out var closest, out _).Succeeded())
 		//        endPos = closest;
@@ -111,25 +236,260 @@ public class NavmeshQuery
 
 		if (useStringPulling)
 		{
-			var straightPath = new List<DtStraightPath>();
-			var success = MeshQuery.FindStraightPath(from.SystemToRecast(), endPos, _lastPath, ref straightPath, 1024, 0);
+			var success = MeshQuery.FindStraightPath(startPos, endPos, _lastPath, ref _straightPath, 1024, 0);
 			if (success.Failed())
-				Service.Log.Error($"Failed to find a path from {from} ({startRef:X}) to {to} ({endRef:X}): failed to find straight path ({success.Value:X})");
-			var res = straightPath.Select(p => new Waypoint(p.pos.RecastToSystem(), GetAreaId(p.refs))).ToList();
+				NavmeshDiagnostics.Error($"Failed to find a path from {from} ({startRef:X}) to {to} ({endRef:X}): failed to find straight path ({success.Value:X})");
+
+			var navmesh = MeshQuery.GetAttachedNavMesh();
+			var res = new List<Waypoint>(_straightPath.Count + 1);
+			foreach (var p in _straightPath)
+				res.Add(new(p.pos.RecastToSystem(), GetAreaId(navmesh, p.refs)));
+
 			res.Add(new(endPos.RecastToSystem()));
 			return res;
 		}
 		else
 		{
-			var res = _lastPath.Select(r => new Waypoint(MeshQuery.GetAttachedNavMesh().GetPolyCenter(r).RecastToSystem(), GetAreaId(r))).ToList();
+			var navmesh = MeshQuery.GetAttachedNavMesh();
+			var res = new List<Waypoint>(_lastPath.Count + 1);
+			foreach (var r in _lastPath)
+				res.Add(new(navmesh.GetPolyCenter(r).RecastToSystem(), GetAreaId(navmesh, r)));
+
 			res.Add(new(endPos.RecastToSystem()));
 			return res;
 		}
 	}
 
-	private Navmesh.AreaId GetAreaId(long refs)
+	public MeshPathfindPhaseResult BenchmarkPathfindMeshPhases(Vector3 from, Vector3 to, bool useRaycast, bool useStringPulling, float range, CancellationToken cancel)
 	{
-		MeshQuery.GetAttachedNavMesh().GetPolyArea(refs, out var area);
+		var allocStart = GC.GetAllocatedBytesForCurrentThread();
+		var totalStart = Stopwatch.GetTimestamp();
+
+		var nearestAllocStart = GC.GetAllocatedBytesForCurrentThread();
+		var nearestStart = Stopwatch.GetTimestamp();
+		var startPos = from.SystemToRecast();
+		var targetPos = to.SystemToRecast();
+		var startRef = FindNearestMeshPoly(startPos);
+		var endRef = FindNearestMeshPoly(targetPos);
+		var nearestTicks = Stopwatch.GetTimestamp() - nearestStart;
+		var nearestAlloc = GC.GetAllocatedBytesForCurrentThread() - nearestAllocStart;
+
+		if (startRef == 0 || endRef == 0)
+			return phaseResult(false, 0, 0, 0, nearestTicks, 0, 0, 0, nearestAlloc, 0, 0, 0, null, $"failed to find polygon on a mesh ({startRef:X} -> {endRef:X})");
+
+		_lastPath.Clear();
+		IDtQueryHeuristic heuristic = range > 0 ? new GoalRadiusHeuristic(range) { Scale = MeshHeuristicScale } : _pathHeuristic;
+		var opt = new DtFindPathOption(heuristic, useRaycast ? DtFindPathOptions.DT_FINDPATH_ANY_ANGLE : 0, useRaycast ? float.MaxValue : 0);
+
+		var findPathAllocStart = GC.GetAllocatedBytesForCurrentThread();
+		var findPathStart = Stopwatch.GetTimestamp();
+		MeshQuery.CollectFindPathStats = true;
+		MeshQuery.FindPath(startRef, endRef, startPos, targetPos, _pathFilter, ref _lastPath, opt);
+		MeshQuery.CollectFindPathStats = false;
+		var findPathStats = MeshQuery.LastFindPathStats;
+		var findPathTicks = Stopwatch.GetTimestamp() - findPathStart;
+		var findPathAlloc = GC.GetAllocatedBytesForCurrentThread() - findPathAllocStart;
+
+		if (_lastPath.Count == 0)
+			return phaseResult(false, 0, 0, 0, nearestTicks, findPathTicks, 0, 0, nearestAlloc, findPathAlloc, 0, 0, findPathStats, "failed to find path on mesh");
+
+		cancel.ThrowIfCancellationRequested();
+
+		var endPos = targetPos;
+		long straightTicks = 0;
+		long waypointTicks;
+		long straightAlloc = 0;
+		long waypointAlloc;
+		int waypoints;
+		int straightPoints = 0;
+
+		if (useStringPulling)
+		{
+			var straightAllocStart = GC.GetAllocatedBytesForCurrentThread();
+			var straightStart = Stopwatch.GetTimestamp();
+			var success = MeshQuery.FindStraightPath(startPos, endPos, _lastPath, ref _straightPath, 1024, 0);
+			straightTicks = Stopwatch.GetTimestamp() - straightStart;
+			straightAlloc = GC.GetAllocatedBytesForCurrentThread() - straightAllocStart;
+			straightPoints = _straightPath.Count;
+
+			if (success.Failed())
+				return phaseResult(false, 0, _lastPath.Count, straightPoints, nearestTicks, findPathTicks, straightTicks, 0, nearestAlloc, findPathAlloc, straightAlloc, 0, findPathStats, $"failed to find straight path ({success.Value:X})");
+
+			var waypointAllocStart = GC.GetAllocatedBytesForCurrentThread();
+			var waypointStart = Stopwatch.GetTimestamp();
+			var navmesh = MeshQuery.GetAttachedNavMesh();
+			var res = new List<Waypoint>(_straightPath.Count + 1);
+			foreach (var p in _straightPath)
+				res.Add(new(p.pos.RecastToSystem(), GetAreaId(navmesh, p.refs)));
+			res.Add(new(endPos.RecastToSystem()));
+			waypoints = res.Count;
+			waypointTicks = Stopwatch.GetTimestamp() - waypointStart;
+			waypointAlloc = GC.GetAllocatedBytesForCurrentThread() - waypointAllocStart;
+		}
+		else
+		{
+			var waypointAllocStart = GC.GetAllocatedBytesForCurrentThread();
+			var waypointStart = Stopwatch.GetTimestamp();
+			var navmesh = MeshQuery.GetAttachedNavMesh();
+			var res = new List<Waypoint>(_lastPath.Count + 1);
+			foreach (var r in _lastPath)
+				res.Add(new(navmesh.GetPolyCenter(r).RecastToSystem(), GetAreaId(navmesh, r)));
+			res.Add(new(endPos.RecastToSystem()));
+			waypoints = res.Count;
+			waypointTicks = Stopwatch.GetTimestamp() - waypointStart;
+			waypointAlloc = GC.GetAllocatedBytesForCurrentThread() - waypointAllocStart;
+		}
+
+		return phaseResult(true, waypoints, _lastPath.Count, straightPoints, nearestTicks, findPathTicks, straightTicks, waypointTicks, nearestAlloc, findPathAlloc, straightAlloc, waypointAlloc, findPathStats, "");
+
+		MeshPathfindPhaseResult phaseResult(bool success, int resultWaypoints, int polyPathCount, int straightPathCount, long nearest, long findPath, long straight, long waypoint, long nearestAllocBytes, long findPathAllocBytes, long straightAllocBytes, long waypointAllocBytes, DtFindPathStats? pathStats, string error)
+		{
+			var totalTicks = Stopwatch.GetTimestamp() - totalStart;
+			var allocBytes = GC.GetAllocatedBytesForCurrentThread() - allocStart;
+			return new(
+				success,
+				resultWaypoints,
+				polyPathCount,
+				straightPathCount,
+				totalTicks,
+				nearest,
+				findPath,
+				straight,
+				waypoint,
+				allocBytes,
+				nearestAllocBytes,
+				findPathAllocBytes,
+				straightAllocBytes,
+				waypointAllocBytes,
+				pathStats?.PoppedNodes ?? 0,
+				pathStats?.TouchedNodes ?? 0,
+				pathStats?.ScannedEdges ?? 0,
+				pathStats?.PassedFilterEdges ?? 0,
+				pathStats?.SkippedParentEdges ?? 0,
+				pathStats?.SkippedSameParentEdges ?? 0,
+				pathStats?.SkippedOpenWorse ?? 0,
+				pathStats?.SkippedClosedWorse ?? 0,
+				pathStats?.PortalCalls ?? 0,
+				pathStats?.CostCalls ?? 0,
+				pathStats?.HeuristicCalls ?? 0,
+				pathStats?.HeapPushes ?? 0,
+				pathStats?.HeapPops ?? 0,
+				pathStats?.HeapModifies ?? 0,
+				pathStats?.MaxOpenList ?? 0,
+				pathStats?.FinalCost ?? 0,
+				error);
+		}
+	}
+
+	private MeshPathCacheKey MakeMeshPathCacheKey(long startRef, long endRef)
+	{
+		return new(startRef, endRef, BitConverter.SingleToInt32Bits(MeshHeuristicScale));
+	}
+
+	private bool TryGetCachedMeshPath(long startRef, long endRef, List<long> path)
+	{
+		var key = MakeMeshPathCacheKey(startRef, endRef);
+		if (!_meshPathCache.TryGetValue(key, out var node))
+			return false;
+
+		_meshPathCacheLru.Remove(node);
+		_meshPathCacheLru.AddFirst(node);
+		path.AddRange(node.Value.Path);
+		return true;
+	}
+
+	private void StoreCachedMeshPath(long startRef, long endRef, List<long> path)
+	{
+		var key = MakeMeshPathCacheKey(startRef, endRef);
+		if (_meshPathCache.TryGetValue(key, out var existing))
+		{
+			existing.Value.Path.Clear();
+			existing.Value.Path.AddRange(path);
+			_meshPathCacheLru.Remove(existing);
+			_meshPathCacheLru.AddFirst(existing);
+			return;
+		}
+
+		var entry = new MeshPathCacheEntry(key, [.. path]);
+		var node = new LinkedListNode<MeshPathCacheEntry>(entry);
+		_meshPathCache.Add(key, node);
+		_meshPathCacheLru.AddFirst(node);
+		TrimMeshPathCache();
+	}
+
+	private void TrimMeshPathCache()
+	{
+		while (_meshPathCache.Count > MeshPathCacheSize)
+		{
+			var node = _meshPathCacheLru.Last;
+			if (node == null)
+				break;
+
+			_meshPathCacheLru.RemoveLast();
+			_meshPathCache.Remove(node.Value.Key);
+		}
+	}
+
+	private static NearestMeshPolyCacheKey MakeNearestMeshPolyCacheKey(RcVec3f p, float halfExtentXZ, float halfExtentY, bool allowUnreachable)
+	{
+		return new(
+			BitConverter.SingleToInt32Bits(p.X),
+			BitConverter.SingleToInt32Bits(p.Y),
+			BitConverter.SingleToInt32Bits(p.Z),
+			BitConverter.SingleToInt32Bits(halfExtentXZ),
+			BitConverter.SingleToInt32Bits(halfExtentY),
+			allowUnreachable);
+	}
+
+	private bool TryGetCachedNearestMeshPoly(RcVec3f p, float halfExtentXZ, float halfExtentY, bool allowUnreachable, out long poly)
+	{
+		var key = MakeNearestMeshPolyCacheKey(p, halfExtentXZ, halfExtentY, allowUnreachable);
+		if (!_nearestMeshPolyCache.TryGetValue(key, out var node))
+		{
+			poly = 0;
+			return false;
+		}
+
+		_nearestMeshPolyCacheLru.Remove(node);
+		_nearestMeshPolyCacheLru.AddFirst(node);
+		poly = node.Value.Poly;
+		return true;
+	}
+
+	private void StoreCachedNearestMeshPoly(RcVec3f p, float halfExtentXZ, float halfExtentY, bool allowUnreachable, long poly)
+	{
+		var key = MakeNearestMeshPolyCacheKey(p, halfExtentXZ, halfExtentY, allowUnreachable);
+		if (_nearestMeshPolyCache.TryGetValue(key, out var existing))
+		{
+			existing.Value.Poly = poly;
+			_nearestMeshPolyCacheLru.Remove(existing);
+			_nearestMeshPolyCacheLru.AddFirst(existing);
+			return;
+		}
+
+		var entry = new NearestMeshPolyCacheEntry(key, poly);
+		var node = new LinkedListNode<NearestMeshPolyCacheEntry>(entry);
+		_nearestMeshPolyCache.Add(key, node);
+		_nearestMeshPolyCacheLru.AddFirst(node);
+		TrimNearestMeshPolyCache();
+	}
+
+	private void TrimNearestMeshPolyCache()
+	{
+		while (_nearestMeshPolyCache.Count > NearestMeshPolyCacheSize)
+		{
+			var node = _nearestMeshPolyCacheLru.Last;
+			if (node == null)
+				break;
+
+			_nearestMeshPolyCacheLru.RemoveLast();
+			_nearestMeshPolyCache.Remove(node.Value.Key);
+		}
+	}
+
+	private static Navmesh.AreaId GetAreaId(DtNavMesh navmesh, long refs)
+	{
+		navmesh.GetPolyArea(refs, out var area);
 		return (Navmesh.AreaId)area;
 	}
 
@@ -137,30 +497,36 @@ public class NavmeshQuery
 	{
 		if (VolumeQuery == null)
 		{
-			Service.Log.Error($"Nav volume was not built");
+			NavmeshDiagnostics.Error($"Nav volume was not built");
 			return [];
 		}
 
 		var startVoxel = FindNearestVolumeVoxel(from);
 		var endVoxel = FindNearestVolumeVoxel(to);
-		Service.Log.Debug($"[pathfind] voxel {startVoxel:X} -> {endVoxel:X}");
+		if (NavmeshDiagnostics.IsDebugEnabled)
+			NavmeshDiagnostics.Debug($"[pathfind] voxel {startVoxel:X} -> {endVoxel:X}");
 		if (startVoxel == VoxelMap.InvalidVoxel || endVoxel == VoxelMap.InvalidVoxel)
 		{
-			Service.Log.Error($"Failed to find a path from {from} ({startVoxel:X}) to {to} ({endVoxel:X}): failed to find empty voxel");
+			NavmeshDiagnostics.Error($"Failed to find a path from {from} ({startVoxel:X}) to {to} ({endVoxel:X}): failed to find empty voxel");
 			return [];
 		}
 
-		var timer = Timer.Create();
+		var debugEnabled = NavmeshDiagnostics.IsDebugEnabled;
+		var timer = debugEnabled ? Timer.Create() : default;
 		var voxelPath = VolumeQuery.FindPath(startVoxel, endVoxel, from, to, useRaycast, false, cancel); // TODO: do we need intermediate points for string-pulling algo?
 		if (voxelPath.Count == 0)
 		{
-			Service.Log.Error($"Failed to find a path from {from} ({startVoxel:X}) to {to} ({endVoxel:X}): failed to find path on volume");
+			NavmeshDiagnostics.Error($"Failed to find a path from {from} ({startVoxel:X}) to {to} ({endVoxel:X}): failed to find path on volume");
 			return [];
 		}
-		Service.Log.Debug($"Pathfind took {timer.Value().TotalSeconds:f3}s: {string.Join(", ", voxelPath.Select(r => $"{r.p} {r.voxel:X}"))}");
+		if (debugEnabled)
+			NavmeshDiagnostics.Debug($"Pathfind took {timer.Value().TotalSeconds:f3}s: {string.Join(", ", voxelPath.Select(r => $"{r.p} {r.voxel:X}"))}");
 
 		// TODO: string-pulling support
-		var res = voxelPath.Select(r => new Waypoint(r.p)).ToList();
+		var res = new List<Waypoint>(voxelPath.Count + 1);
+		foreach (var r in voxelPath)
+			res.Add(new(r.p));
+
 		res.Add(new(to));
 		return res;
 	}
@@ -168,7 +534,23 @@ public class NavmeshQuery
 	// returns 0 if not found, otherwise polygon ref
 	public long FindNearestMeshPoly(Vector3 p, float halfExtentXZ = 5, float halfExtentY = 5, bool allowUnreachable = true)
 	{
-		MeshQuery.FindNearestPoly(p.SystemToRecast(), new(halfExtentXZ, halfExtentY, halfExtentXZ), allowUnreachable ? _filter : _reachableFilter, out var nearestRef, out _, out _);
+		return FindNearestMeshPoly(p.SystemToRecast(), halfExtentXZ, halfExtentY, allowUnreachable);
+	}
+
+	private long FindNearestMeshPoly(RcVec3f p, float halfExtentXZ = 5, float halfExtentY = 5, bool allowUnreachable = true)
+	{
+		if (NearestMeshPolyCacheSize > 0 && TryGetCachedNearestMeshPoly(p, halfExtentXZ, halfExtentY, allowUnreachable, out var cachedRef))
+		{
+			NearestMeshPolyCacheHits++;
+			return cachedRef;
+		}
+
+		if (NearestMeshPolyCacheSize > 0)
+			NearestMeshPolyCacheMisses++;
+
+		MeshQuery.FindNearestPoly(p, new(halfExtentXZ, halfExtentY, halfExtentXZ), allowUnreachable ? _filter : _reachableFilter, out var nearestRef, out _, out _);
+		if (NearestMeshPolyCacheSize > 0 && nearestRef != 0)
+			StoreCachedNearestMeshPoly(p, halfExtentXZ, halfExtentY, allowUnreachable, nearestRef);
 		return nearestRef;
 	}
 

--- a/vnavmesh/Plugin.cs
+++ b/vnavmesh/Plugin.cs
@@ -3,6 +3,7 @@ using Dalamud.Game.Command;
 using Dalamud.Interface.Windowing;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
+using Navmesh.Benchmarking;
 using Navmesh.Movement;
 using System;
 using System.IO;
@@ -36,6 +37,8 @@ public sealed class Plugin : IDalamudPlugin
         dalamud.Create<Service>();
         Service.Config.Load(dalamud.ConfigFile);
         Service.Config.Modified += () => Service.Config.Save(dalamud.ConfigFile);
+        NavmeshDiagnostics.ErrorSink = message => Service.Log.Error(message);
+        NavmeshDiagnostics.RandomnessMultiplierProvider = () => Service.Config.RandomnessMultiplier;
 
         _navmeshManager = new(new($"{dalamud.ConfigDirectory.FullName}/meshcache"));
         _followPath = new(dalamud, _navmeshManager);
@@ -65,6 +68,7 @@ public sealed class Plugin : IDalamudPlugin
             /vnav stop → stop all movement
             /vnav reload → reload current territory's navmesh from cache
             /vnav rebuild → rebuild current territory's navmesh from scratch
+            /vnav benchcapture [name] [pairs] → save a benchmark snapshot for offline pathfinding tests
             /vnav aligncamera → toggle aligning camera to movement direction
             /vnav aligncamera true|yes|enable → enable aligning camera to movement direction
             /vnav aligncamera false|no|disable → disable aligning camera to movement direction
@@ -95,6 +99,8 @@ public sealed class Plugin : IDalamudPlugin
         _asyncMove.Dispose();
         _followPath.Dispose();
         _navmeshManager.Dispose();
+        NavmeshDiagnostics.ErrorSink = null;
+        NavmeshDiagnostics.RandomnessMultiplierProvider = static () => 1f;
     }
 
     public static void DuoLog(Exception ex)
@@ -141,6 +147,9 @@ public sealed class Plugin : IDalamudPlugin
                 break;
             case "rebuild":
                 _navmeshManager.Reload(false);
+                break;
+            case "benchcapture":
+                BenchCaptureCommand(args);
                 break;
             case "moveto":
                 MoveToCommand(args, false, false);
@@ -213,6 +222,26 @@ public sealed class Plugin : IDalamudPlugin
         if (pt == null)
             return;
         _asyncMove.MoveTo(pt.Value, fly);
+    }
+
+    private void BenchCaptureCommand(string[] args)
+    {
+        var name = args.Length > 1 ? args[1] : DateTime.UtcNow.ToString("yyyyMMdd-HHmmss");
+        var pairs = 100;
+        if (args.Length > 2 && int.TryParse(args[2], out var parsedPairs))
+            pairs = parsedPairs;
+
+        try
+        {
+            var directory = BenchmarkCapture.Capture(_navmeshManager, Service.PluginInterface.ConfigDirectory.FullName, name, pairs);
+            Service.ChatGui.Print($"[{Service.PluginInterface.Manifest.Name}] Benchmark snapshot saved: {directory}");
+            Service.Log.Info($"Benchmark snapshot saved: {directory}");
+        }
+        catch (Exception ex)
+        {
+            Service.ChatGui.PrintError($"[{Service.PluginInterface.Manifest.Name}] Benchmark snapshot failed: {ex.Message}");
+            Service.Log.Error(ex, "Benchmark snapshot failed");
+        }
     }
 
     private void AlignCameraCommand(string arg)


### PR DESCRIPTION
## Summary
- Updates the DotRecast submodule to the pathfinding optimization commit (`09fa9a6`).
- Adds an offline navmesh benchmark harness and `/vnav benchcapture [name] [pairs]` snapshot capture command.
- Adds mesh path and nearest-poly caches in `NavmeshQuery`, plus `MeshHeuristicScale` tuning.
- Splits mesh and volume raycast toggles so mesh raycasts can default off while volume raycasts remain enabled.
- Fixes navmesh serialization tile counts to count actual valid tiles.

This draft depends on the DotRecast PR: https://github.com/xanunderscore/DotRecast/pull/1

The previous experimental hierarchical/tile-corridor pathfinding changes are not included here.

## Benchmarks
Snapshot: `C:\Users\nabej\AppData\Roaming\XIVLauncher\pluginConfigs\vnavmesh\benchmarks\test2`

Configuration: 200 mesh pairs, 100 iterations, 20 warmup iterations, TerritoryId 132, 93 loaded tiles, 15501 polys, string pulling enabled.

| Case | Raycast | Heuristic | Caches | Success | Median | P95 | P99 |
| --- | --- | ---: | --- | ---: | ---: | ---: | ---: |
| Old default-like | on | 1 | off | 20000/20000 | 291.0 us | 3325.9 us | 4929.2 us |
| No raycast baseline | off | 1 | off | 20000/20000 | 146.9 us | 1674.7 us | 2358.0 us |
| Optimized cold | off | 10 | off | 20000/20000 | 117.3 us | 862.8 us | 1550.0 us |
| Optimized default cache | off | 10 | mesh 2048 / nearest 4096 | 20000/20000 | 6.8 us | 28.3 us | 36.8 us |

Smoke after cleanup: 1000/1000 success, 1000/1000 cache hits, median 8.1 us, P95 31.3 us, P99 40.4 us.

## Validation
- `dotnet build vnavmesh.sln -c Release --nologo`
- Offline benchmark CSVs generated with `vnavmesh.Benchmarks`
